### PR TITLE
Add device info for workshift entities

### DIFF
--- a/custom_components/workshift_sensor/binary_sensor.py
+++ b/custom_components/workshift_sensor/binary_sensor.py
@@ -5,6 +5,7 @@ import logging
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_point_in_time
 
 from . import DOMAIN
@@ -27,7 +28,7 @@ class WorkshiftActiveSensor(BinarySensorEntity):
         self._entry = entry
         self._config = hass.data[DOMAIN][entry.entry_id]
         self._attr_name = f"{name_prefix} Active"
-        self._attr_unique_id = f"{name_prefix.lower()}_active"
+        self._attr_unique_id = f"{entry.entry_id}_active"
         # Parse config values
         self._shift_duration = int(self._config.get("shift_duration", 8))
         self._num_shifts = int(self._config.get("num_shifts", 1))
@@ -163,3 +164,13 @@ class WorkshiftActiveSensor(BinarySensorEntity):
         self.async_write_ha_state()
         # Schedule the next transition
         self._schedule_next_event()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this entity."""
+        name = self._config.get("name") or self._entry.title or "Workshift"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=name,
+            manufacturer="Workshift Sensor",
+        )

--- a/custom_components/workshift_sensor/sensor.py
+++ b/custom_components/workshift_sensor/sensor.py
@@ -5,6 +5,7 @@ import logging
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import (
     async_track_point_in_time,
     async_track_state_change_event,
@@ -36,11 +37,12 @@ class WorkshiftDaySensor(SensorEntity):
         offset: int,
     ):
         self.hass = hass
+        self._entry = entry
         self._config = hass.data[DOMAIN][entry.entry_id]
         self._offset = offset
         suffix = "today" if offset == 0 else "tomorrow"
         self._attr_name = f"{name} {suffix.title()}"
-        self._attr_unique_id = f"{name.lower()}_{suffix}"
+        self._attr_unique_id = f"{entry.entry_id}_day_{suffix}"
         self._attr_extra_state_attributes: dict[str, Any] = {}
 
         # Parametry zmian
@@ -145,3 +147,13 @@ class WorkshiftDaySensor(SensorEntity):
                 "shift_start": start_dt.isoformat(),
                 "shift_end": end_dt.isoformat(),
             }
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this entity."""
+        name = self._config.get("name") or self._entry.title or "Workshift"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=name,
+            manufacturer="Workshift Sensor",
+        )


### PR DESCRIPTION
## Summary
- add device information so each config entry registers a dedicated device
- ensure unique IDs include the config entry identifier for sensors

## Testing
- python -m compileall custom_components/workshift_sensor

------
https://chatgpt.com/codex/tasks/task_e_68d924b0ea2c832e881fd96281fbe4d7