### PR TITLE
Add options flow and improve workshift scheduling resilience

### DIFF
--- a/custom_components/workshift_sensor/__init__.py
+++ b/custom_components/workshift_sensor/__init__.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
@@ -11,18 +13,37 @@ PLATFORMS: list[str] = ["sensor", "binary_sensor"]
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _merged_entry_data(entry: ConfigEntry) -> dict[str, Any]:
+    """Return config entry data with options merged in."""
+    data: dict[str, Any] = dict(entry.data)
+    if entry.options:
+        data.update(entry.options)
+    return data
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up via YAML (not supported)."""
     return True
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Workshift Sensor from a config entry."""
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _merged_entry_data(entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    hass.data[DOMAIN].pop(entry.entry_id, None)
-    return True
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unload_ok
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle updates to the config entry options."""
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _merged_entry_data(entry)
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/workshift_sensor/binary_sensor.py
+++ b/custom_components/workshift_sensor/binary_sensor.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
-from datetime import datetime, timedelta, date
-from typing import Optional
+from datetime import date, datetime, timedelta
+from typing import Callable, Optional
 import logging
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.util import dt as dt_util
 
 from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
     """Set up the 'active shift' binary sensor."""
     data = hass.data[DOMAIN][entry.entry_id]
     name_prefix = data.get("name", "Workshift")
@@ -32,7 +36,10 @@ class WorkshiftActiveSensor(BinarySensorEntity):
         # Parse config values
         self._shift_duration = int(self._config.get("shift_duration", 8))
         self._num_shifts = int(self._config.get("num_shifts", 1))
-        self._start_times = [datetime.strptime(t, "%H:%M").time() for t in self._config.get("start_times", [])]
+        self._start_times = [
+            datetime.strptime(t, "%H:%M").time()
+            for t in self._config.get("start_times", [])
+        ]
         self._pattern = str(self._config.get("schedule", ""))
         try:
             self._base_date = datetime.strptime(self._config.get("schedule_start"), "%Y-%m-%d").date()
@@ -41,15 +48,14 @@ class WorkshiftActiveSensor(BinarySensorEntity):
         self._workday_entity = self._config.get("workday_sensor")
         self._use_workday_sensor = self._config.get("use_workday_sensor", True)
         # Timer for scheduled state changes
-        self._timer_cancel: Optional[callback] = None
+        self._timer_cancel: Optional[Callable[[], None]] = None
         self._attr_is_on = False  # initial state
 
     async def async_added_to_hass(self):
         """When added, determine initial state and set up timers."""
-        # Set initial state
-        self._attr_is_on = self._is_shift_active_now()
-        # Schedule the next state change
-        self._schedule_next_event()
+        now = dt_util.now()
+        self._attr_is_on = self._is_shift_active(now)
+        self._schedule_next_event(now)
         # Write initial state
         self.async_write_ha_state()
 
@@ -66,8 +72,12 @@ class WorkshiftActiveSensor(BinarySensorEntity):
         days_diff = (day - self._base_date).days
         if days_diff < 0:
             return 0
-        idx = days_diff % len(self._pattern) if self._pattern else 0
-        code = int(self._pattern[idx]) if idx < len(self._pattern) else 0
+        idx = days_diff % len(self._pattern)
+        try:
+            code = int(self._pattern[idx])
+        except (ValueError, IndexError):
+            _LOGGER.warning("Invalid schedule digit for day %s in pattern %s", day, self._pattern)
+            return 0
         # Override as off if workday sensor indicates a non-workday and use_workday_sensor is enabled
         if self._use_workday_sensor and self._workday_entity:
             if day == date.today():
@@ -76,39 +86,52 @@ class WorkshiftActiveSensor(BinarySensorEntity):
                     return 0
         return code
 
-    def _is_shift_active_now(self) -> bool:
+    def _start_datetime(self, day: date, index: int):
+        if index < len(self._start_times):
+            start_time = self._start_times[index]
+        else:
+            _LOGGER.warning(
+                "Start time for shift %s missing, defaulting to 00:00", index + 1
+            )
+            start_time = datetime.strptime("00:00", "%H:%M").time()
+        start_of_day = dt_util.start_of_local_day(day)
+        return start_of_day + timedelta(
+            hours=start_time.hour,
+            minutes=start_time.minute,
+            seconds=start_time.second,
+        )
+
+    def _is_shift_active(self, reference: datetime) -> bool:
         """Check if currently within any active shift interval."""
-        now = datetime.now()
-        today = now.date()
+        reference = dt_util.as_local(reference)
+        today = reference.date()
         code_today = self._get_schedule_code(today)
         if code_today != 0:
             idx = code_today - 1
-            start_time = self._start_times[idx] if idx < len(self._start_times) else datetime.strptime("00:00", "%H:%M").time()
-            start_dt = datetime.combine(today, start_time)
+            start_dt = self._start_datetime(today, idx)
             end_dt = start_dt + timedelta(hours=self._shift_duration)
-            if start_dt <= now < end_dt:
-                # Currently within today's shift interval
+            if start_dt <= reference < end_dt:
                 return True
         # If not, check if a shift from yesterday overlaps into now
         yesterday = today - timedelta(days=1)
         code_yest = self._get_schedule_code(yesterday)
         if code_yest != 0:
             idx = code_yest - 1
-            y_start_time = self._start_times[idx] if idx < len(self._start_times) else datetime.strptime("00:00", "%H:%M").time()
-            y_start_dt = datetime.combine(yesterday, y_start_time)
+            y_start_dt = self._start_datetime(yesterday, idx)
             y_end_dt = y_start_dt + timedelta(hours=self._shift_duration)
-            if y_end_dt.date() == today and now < y_end_dt:
-                # Yesterday's shift continues into today
+            if y_end_dt.date() == today and reference < y_end_dt:
                 return True
         return False
 
-    def _schedule_next_event(self):
+    def _schedule_next_event(self, now: datetime | None = None) -> None:
         """Schedule the next on/off state transition."""
         # Cancel any existing timer
         if self._timer_cancel:
             self._timer_cancel()
             self._timer_cancel = None
-        now = datetime.now()
+        if now is None:
+            now = dt_util.now()
+        now = dt_util.as_local(now)
         today = now.date()
         target_time = None
         if self._attr_is_on:
@@ -116,7 +139,7 @@ class WorkshiftActiveSensor(BinarySensorEntity):
             code_today = self._get_schedule_code(today)
             if code_today != 0:
                 idx = code_today - 1
-                start_dt = datetime.combine(today, self._start_times[idx] if idx < len(self._start_times) else datetime.strptime("00:00","%H:%M").time())
+                start_dt = self._start_datetime(today, idx)
                 end_dt = start_dt + timedelta(hours=self._shift_duration)
                 if now < end_dt:
                     target_time = end_dt
@@ -126,19 +149,21 @@ class WorkshiftActiveSensor(BinarySensorEntity):
                 code_yest = self._get_schedule_code(yesterday)
                 if code_yest != 0:
                     idx = code_yest - 1
-                    y_start_dt = datetime.combine(yesterday, self._start_times[idx] if idx < len(self._start_times) else datetime.strptime("00:00","%H:%M").time())
+                    y_start_dt = self._start_datetime(yesterday, idx)
                     y_end_dt = y_start_dt + timedelta(hours=self._shift_duration)
                     if now < y_end_dt:
                         target_time = y_end_dt
             if target_time:
                 _LOGGER.debug("Scheduling shift end at %s", target_time)
-                self._timer_cancel = async_track_point_in_time(self.hass, self._timer_trigger, target_time)
+                self._timer_cancel = async_track_point_in_time(
+                    self.hass, self._timer_trigger, dt_util.as_utc(target_time)
+                )
         else:
             # Currently off: schedule next shift start
             code_today = self._get_schedule_code(today)
             if code_today != 0:
                 idx = code_today - 1
-                start_dt = datetime.combine(today, self._start_times[idx] if idx < len(self._start_times) else datetime.strptime("00:00","%H:%M").time())
+                start_dt = self._start_datetime(today, idx)
                 if now < start_dt:
                     target_time = start_dt
             if target_time is None:
@@ -148,22 +173,25 @@ class WorkshiftActiveSensor(BinarySensorEntity):
                     code_future = self._get_schedule_code(future_date)
                     if code_future != 0:
                         idx = code_future - 1
-                        start_dt = datetime.combine(future_date, self._start_times[idx] if idx < len(self._start_times) else datetime.strptime("00:00","%H:%M").time())
+                        start_dt = self._start_datetime(future_date, idx)
                         if start_dt > now:
                             target_time = start_dt
                             break
             if target_time:
                 _LOGGER.debug("Scheduling shift start at %s", target_time)
-                self._timer_cancel = async_track_point_in_time(self.hass, self._timer_trigger, target_time)
+                self._timer_cancel = async_track_point_in_time(
+                    self.hass, self._timer_trigger, dt_util.as_utc(target_time)
+                )
 
     @callback
     def _timer_trigger(self, _now: datetime):
         """Handle a scheduled state change event."""
         # Update the current state
-        self._attr_is_on = self._is_shift_active_now()
+        reference = dt_util.now()
+        self._attr_is_on = self._is_shift_active(reference)
         self.async_write_ha_state()
         # Schedule the next transition
-        self._schedule_next_event()
+        self._schedule_next_event(reference)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/workshift_sensor/config_flow.py
+++ b/custom_components/workshift_sensor/config_flow.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
-from datetime import datetime, date, timedelta
-from typing import Any
+
+from datetime import date, datetime, timedelta
+from typing import Any, Iterable
+
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.selector as selector
 
 from . import DOMAIN
@@ -27,90 +29,171 @@ def _default_last_monday() -> str:
     last_monday = today - timedelta(days=days_since)
     return last_monday.strftime("%Y-%m-%d")
 
+
+def _sanitize_optional(value: Any) -> Any:
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    return value
+
+
+def _user_schema(data: dict[str, Any]) -> vol.Schema:
+    default_name = data.get(CONF_NAME, "")
+    default_use_workday = data.get(CONF_USE_WORKDAY_SENSOR, True)
+    default_workday = data.get(CONF_WORKDAY_SENSOR)
+    if default_workday is None:
+        default_workday = "binary_sensor.workday_sensor"
+    default_tomorrow = data.get(CONF_WORKDAY_SENSOR_TOMORROW) or default_workday
+
+    fields: dict[Any, Any] = {
+        vol.Required(CONF_NAME, default=default_name): selector.TextSelector(),
+        vol.Required(CONF_USE_WORKDAY_SENSOR, default=default_use_workday): selector.BooleanSelector(),
+        vol.Optional(CONF_WORKDAY_SENSOR, default=default_workday): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain="binary_sensor")
+        ),
+        vol.Optional(CONF_WORKDAY_SENSOR_TOMORROW, default=default_tomorrow): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain="binary_sensor")
+        ),
+    }
+    return vol.Schema(fields)
+
+
+def _shift_schema(data: dict[str, Any]) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(CONF_SHIFT_DURATION, default=data.get(CONF_SHIFT_DURATION, 8)): vol.Coerce(int),
+            vol.Required(CONF_NUM_SHIFTS, default=data.get(CONF_NUM_SHIFTS, 3)): vol.Coerce(int),
+        }
+    )
+
+
+def _start_times_schema(data: dict[str, Any]) -> vol.Schema:
+    num_shifts = int(data.get(CONF_NUM_SHIFTS, 1))
+    defaults: list[str] = list(data.get(CONF_START_TIMES, []))
+    duration = int(data.get(CONF_SHIFT_DURATION, 8))
+    base = datetime.strptime("06:00", "%H:%M")
+    fields: dict[Any, Any] = {}
+    for i in range(1, num_shifts + 1):
+        if i - 1 < len(defaults):
+            default = defaults[i - 1]
+        else:
+            default = (base + timedelta(hours=duration * (i - 1))).strftime("%H:%M")
+        fields[vol.Required(f"{CONF_START_TIMES}_{i}", default=default)] = str
+    return vol.Schema(fields)
+
+
+def _schedule_schema(data: dict[str, Any]) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_SCHEDULE_START,
+                default=data.get(CONF_SCHEDULE_START, _default_last_monday()),
+            ): str,
+            vol.Required(CONF_SCHEDULE, default=data.get(CONF_SCHEDULE, "")): str,
+        }
+    )
+
+
+def _start_times_sorted(times: Iterable[str]) -> bool:
+    minutes: list[int] = []
+    for value in times:
+        hour, minute = value.split(":")
+        minutes.append(int(hour) * 60 + int(minute))
+    return all(curr > prev for prev, curr in zip(minutes, minutes[1:]))
+
+
+def _name_in_use(hass: HomeAssistant, name: str, *, exclude_entry_id: str | None = None) -> bool:
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.entry_id == exclude_entry_id:
+            continue
+        existing_name = (
+            entry.options.get(CONF_NAME)
+            or entry.data.get(CONF_NAME)
+            or entry.title
+        )
+        if existing_name == name:
+            return True
+    return False
+
+
 class WorkshiftConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._data: dict[str, Any] = {}
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         errors: dict[str, str] = {}
         if user_input is not None:
-            for entry in self._async_current_entries():
-                if entry.data.get(CONF_NAME) == user_input[CONF_NAME]:
-                    errors["base"] = "name_exists"
-                    break
+            candidate = {**self._data, **user_input}
+            candidate[CONF_NAME] = candidate.get(CONF_NAME, "").strip()
+            if not candidate[CONF_NAME]:
+                errors["base"] = "invalid_name"
+            elif _name_in_use(self.hass, candidate[CONF_NAME]):
+                errors["base"] = "name_exists"
+            elif (
+                candidate.get(CONF_USE_WORKDAY_SENSOR, True)
+                and not candidate.get(CONF_WORKDAY_SENSOR)
+            ):
+                errors["base"] = "workday_required"
             if not errors:
-                self._data.update(user_input)
+                self._data[CONF_NAME] = candidate[CONF_NAME]
+                self._data[CONF_USE_WORKDAY_SENSOR] = candidate.get(CONF_USE_WORKDAY_SENSOR, True)
+                self._data[CONF_WORKDAY_SENSOR] = _sanitize_optional(candidate.get(CONF_WORKDAY_SENSOR))
+                self._data[CONF_WORKDAY_SENSOR_TOMORROW] = _sanitize_optional(
+                    candidate.get(CONF_WORKDAY_SENSOR_TOMORROW)
+                )
                 return await self.async_step_shifts()
 
-        default_name = self._data.get(CONF_NAME, "")
-        default_workday = self._data.get(CONF_WORKDAY_SENSOR, "binary_sensor.workday_sensor")
-        default_tomorrow = self._data.get(CONF_WORKDAY_SENSOR_TOMORROW, default_workday)
-        default_use_workday = self._data.get(CONF_USE_WORKDAY_SENSOR, True)
-        schema = vol.Schema({
-            vol.Required(CONF_NAME, default=default_name): selector.TextSelector(),
-            vol.Required(CONF_USE_WORKDAY_SENSOR, default=default_use_workday): selector.BooleanSelector(),
-            vol.Required(CONF_WORKDAY_SENSOR, default=default_workday): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="binary_sensor")
-            ),
-            vol.Optional(CONF_WORKDAY_SENSOR_TOMORROW, default=default_tomorrow): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="binary_sensor")
-            ),
-        })
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_user_schema(self._data),
+            errors=errors,
+        )
 
     async def async_step_shifts(self, user_input: dict[str, Any] | None = None):
         errors: dict[str, str] = {}
         if user_input is not None:
-            num = user_input.get(CONF_NUM_SHIFTS)
-            if num is None or num < 1 or num > 9:
+            duration = int(user_input.get(CONF_SHIFT_DURATION, 0))
+            num = int(user_input.get(CONF_NUM_SHIFTS, 0))
+            if duration <= 0:
+                errors["base"] = "invalid_shift_duration"
+            elif num < 1 or num > 9:
                 errors["base"] = "invalid_num_shifts"
             if not errors:
-                self._data.update(user_input)
+                self._data[CONF_SHIFT_DURATION] = duration
+                self._data[CONF_NUM_SHIFTS] = num
                 return await self.async_step_start_times()
 
-        schema = vol.Schema({
-            vol.Required(CONF_SHIFT_DURATION, default=self._data.get(CONF_SHIFT_DURATION, 8)): vol.Coerce(int),
-            vol.Required(CONF_NUM_SHIFTS, default=self._data.get(CONF_NUM_SHIFTS, 3)): vol.Coerce(int),
-        })
-        return self.async_show_form(step_id="shifts", data_schema=schema, errors=errors)
+        return self.async_show_form(
+            step_id="shifts",
+            data_schema=_shift_schema(self._data),
+            errors=errors,
+        )
 
     async def async_step_start_times(self, user_input: dict[str, Any] | None = None):
         errors: dict[str, str] = {}
-        num_shifts = self._data.get(CONF_NUM_SHIFTS, 1)
-        defaults = self._data.get(CONF_START_TIMES, [])
-        schema_fields: dict = {}
-        base = datetime.strptime("06:00", "%H:%M")
-        duration = self._data.get(CONF_SHIFT_DURATION, 8)
-        for i in range(1, num_shifts + 1):
-            if i-1 < len(defaults):
-                default = defaults[i-1]
-            else:
-                default = (base + timedelta(hours=duration*(i-1))).strftime("%H:%M")
-            schema_fields[vol.Required(f"{CONF_START_TIMES}_{i}", default=default)] = str
-        schema = vol.Schema(schema_fields)
-
         if user_input is not None:
+            num_shifts = int(self._data.get(CONF_NUM_SHIFTS, 1))
             times: list[str] = []
             for i in range(1, num_shifts + 1):
-                t = user_input.get(f"{CONF_START_TIMES}_{i}")
+                value = user_input.get(f"{CONF_START_TIMES}_{i}")
                 try:
-                    datetime.strptime(t, "%H:%M")
-                except Exception:
+                    datetime.strptime(value, "%H:%M")
+                except (TypeError, ValueError):
                     errors["base"] = "invalid_time_format"
-                times.append(t)
-            if not errors and any(
-                int(times[i].split(':')[0])*60+int(times[i].split(':')[1]) >=
-                int(times[i+1].split(':')[0])*60+int(times[i+1].split(':')[1])
-                for i in range(len(times)-1)
-            ):
+                    break
+                times.append(value)
+            if not errors and not _start_times_sorted(times):
                 errors["base"] = "times_not_sorted"
             if not errors:
                 self._data[CONF_START_TIMES] = times
                 return await self.async_step_schedule()
 
-        return self.async_show_form(step_id="start_times", data_schema=schema, errors=errors)
+        return self.async_show_form(
+            step_id="start_times",
+            data_schema=_start_times_schema(self._data),
+            errors=errors,
+        )
 
     async def async_step_schedule(self, user_input: dict[str, Any] | None = None):
         errors: dict[str, str] = {}
@@ -121,20 +204,140 @@ class WorkshiftConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except Exception:
                 errors["base"] = "invalid_date"
             sched = user_input.get(CONF_SCHEDULE, "")
-            if not sched.isdigit() or any(int(ch) > self._data.get(CONF_NUM_SHIFTS,1) for ch in sched):
+            if sched and (
+                not sched.isdigit()
+                or any(int(ch) > self._data.get(CONF_NUM_SHIFTS, 1) for ch in sched)
+            ):
                 errors["base"] = "invalid_schedule"
             if not errors:
                 self._data[CONF_SCHEDULE_START] = date_str
                 self._data[CONF_SCHEDULE] = sched
                 return self.async_create_entry(title=self._data[CONF_NAME], data=self._data)
 
-        schema = vol.Schema({
-            vol.Required(CONF_SCHEDULE_START, default=self._data.get(CONF_SCHEDULE_START, _default_last_monday())): str,
-            vol.Required(CONF_SCHEDULE, default=self._data.get(CONF_SCHEDULE, "")): str,
-        })
         return self.async_show_form(
             step_id="schedule",
-            data_schema=schema,
+            data_schema=_schedule_schema(self._data),
             errors=errors,
-            description_placeholders={"max": self._data.get(CONF_NUM_SHIFTS,1)}
+            description_placeholders={"max": self._data.get(CONF_NUM_SHIFTS, 1)},
         )
+
+
+class WorkshiftOptionsFlow(config_entries.OptionsFlow):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+        self._data: dict[str, Any] = {**config_entry.data, **config_entry.options}
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        return await self.async_step_user(user_input)
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            candidate = {**self._data, **user_input}
+            candidate[CONF_NAME] = candidate.get(CONF_NAME, "").strip()
+            if not candidate[CONF_NAME]:
+                errors["base"] = "invalid_name"
+            elif _name_in_use(
+                self.hass,
+                candidate[CONF_NAME],
+                exclude_entry_id=self.config_entry.entry_id,
+            ):
+                errors["base"] = "name_exists"
+            elif (
+                candidate.get(CONF_USE_WORKDAY_SENSOR, True)
+                and not candidate.get(CONF_WORKDAY_SENSOR)
+            ):
+                errors["base"] = "workday_required"
+            if not errors:
+                self._data[CONF_NAME] = candidate[CONF_NAME]
+                self._data[CONF_USE_WORKDAY_SENSOR] = candidate.get(CONF_USE_WORKDAY_SENSOR, True)
+                self._data[CONF_WORKDAY_SENSOR] = _sanitize_optional(candidate.get(CONF_WORKDAY_SENSOR))
+                self._data[CONF_WORKDAY_SENSOR_TOMORROW] = _sanitize_optional(
+                    candidate.get(CONF_WORKDAY_SENSOR_TOMORROW)
+                )
+                return await self.async_step_shifts()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_user_schema(self._data),
+            errors=errors,
+        )
+
+    async def async_step_shifts(self, user_input: dict[str, Any] | None = None):
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            duration = int(user_input.get(CONF_SHIFT_DURATION, 0))
+            num = int(user_input.get(CONF_NUM_SHIFTS, 0))
+            if duration <= 0:
+                errors["base"] = "invalid_shift_duration"
+            elif num < 1 or num > 9:
+                errors["base"] = "invalid_num_shifts"
+            if not errors:
+                self._data[CONF_SHIFT_DURATION] = duration
+                self._data[CONF_NUM_SHIFTS] = num
+                return await self.async_step_start_times()
+
+        return self.async_show_form(
+            step_id="shifts",
+            data_schema=_shift_schema(self._data),
+            errors=errors,
+        )
+
+    async def async_step_start_times(self, user_input: dict[str, Any] | None = None):
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            num_shifts = int(self._data.get(CONF_NUM_SHIFTS, 1))
+            times: list[str] = []
+            for i in range(1, num_shifts + 1):
+                value = user_input.get(f"{CONF_START_TIMES}_{i}")
+                try:
+                    datetime.strptime(value, "%H:%M")
+                except (TypeError, ValueError):
+                    errors["base"] = "invalid_time_format"
+                    break
+                times.append(value)
+            if not errors and not _start_times_sorted(times):
+                errors["base"] = "times_not_sorted"
+            if not errors:
+                self._data[CONF_START_TIMES] = times
+                return await self.async_step_schedule()
+
+        return self.async_show_form(
+            step_id="start_times",
+            data_schema=_start_times_schema(self._data),
+            errors=errors,
+        )
+
+    async def async_step_schedule(self, user_input: dict[str, Any] | None = None):
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            date_str = user_input.get(CONF_SCHEDULE_START)
+            try:
+                datetime.strptime(date_str, "%Y-%m-%d")
+            except Exception:
+                errors["base"] = "invalid_date"
+            sched = user_input.get(CONF_SCHEDULE, "")
+            if sched and (
+                not sched.isdigit()
+                or any(int(ch) > self._data.get(CONF_NUM_SHIFTS, 1) for ch in sched)
+            ):
+                errors["base"] = "invalid_schedule"
+            if not errors:
+                self._data[CONF_SCHEDULE_START] = date_str
+                self._data[CONF_SCHEDULE] = sched
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    title=self._data[CONF_NAME],
+                )
+                return self.async_create_entry(title="", data=self._data)
+
+        return self.async_show_form(
+            step_id="schedule",
+            data_schema=_schedule_schema(self._data),
+            errors=errors,
+            description_placeholders={"max": self._data.get(CONF_NUM_SHIFTS, 1)},
+        )
+
+
+async def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+    return WorkshiftOptionsFlow(config_entry)

--- a/custom_components/workshift_sensor/sensor.py
+++ b/custom_components/workshift_sensor/sensor.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
-from datetime import datetime, timedelta, date, time as time_
-from typing import Any
+from datetime import date, datetime, timedelta
+from typing import Any, Callable, Optional
 import logging
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.event import (
-    async_track_point_in_time,
-    async_track_state_change_event,
-)
+from homeassistant.helpers.event import async_track_point_in_time, async_track_state_change_event
+from homeassistant.util import dt as dt_util
 
 from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     name = data.get("name", "Workshift")
     async_add_entities([
@@ -49,7 +50,8 @@ class WorkshiftDaySensor(SensorEntity):
         self.shift_duration = int(self._config.get("shift_duration", 8))
         self.num_shifts = int(self._config.get("num_shifts", 1))
         self.start_times = [
-            datetime.strptime(t, "%H:%M").time() for t in self._config.get("start_times", [])
+            datetime.strptime(t, "%H:%M").time()
+            for t in self._config.get("start_times", [])
         ]
         # Harmonogram jako ciąg cyfr
         self._pattern = str(self._config.get("schedule", ""))
@@ -62,49 +64,69 @@ class WorkshiftDaySensor(SensorEntity):
 
         # Ustawienia dla workday sensor
         self._use_workday_sensor = self._config.get("use_workday_sensor", True)
+        self._workday_today = None
+        self._workday_tomorrow = None
         if self._use_workday_sensor:
-            if offset == 0:
-                self._workday_today = self._config.get("workday_sensor")
-                self._workday_tomorrow = self._config.get("workday_sensor_tomorrow") or self._workday_today
-            else:
-                self._workday_today = self._config.get("workday_sensor")
-                self._workday_tomorrow = self._config.get("workday_sensor_tomorrow") or self._workday_today
-        else:
-            self._workday_today = None
-            self._workday_tomorrow = None
+            self._workday_today = self._config.get("workday_sensor")
+            self._workday_tomorrow = (
+                self._config.get("workday_sensor_tomorrow") or self._workday_today
+            )
+
+        self._midnight_unsub: Optional[Callable[[], None]] = None
+        self._workday_unsub: Optional[Callable[[], None]] = None
 
     async def async_added_to_hass(self):
         """Odświeżenie o północy + nasłuchiwanie zmian workday_sensor i workday_sensor_tomorrow."""
         # Inicjalne odświeżenie
-        self._update_state()
+        self._update_state(dt_util.now())
         self.async_write_ha_state()
 
         # 1) Harmonogram o północy
-        now = datetime.now()
-        next_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        now = dt_util.now()
+        next_midnight = dt_util.start_of_local_day(now.date() + timedelta(days=1))
 
         @callback
-        def midnight_cb(ts: datetime):
-            self._update_state()
+        def midnight_cb(ts: datetime) -> None:
+            self._update_state(dt_util.now())
             self.async_write_ha_state()
-            async_track_point_in_time(self.hass, midnight_cb, ts + timedelta(days=1))
+            self._midnight_unsub = async_track_point_in_time(
+                self.hass, midnight_cb, dt_util.as_utc(ts + timedelta(days=1))
+            )
 
-        async_track_point_in_time(self.hass, midnight_cb, next_midnight)
+        self._midnight_unsub = async_track_point_in_time(
+            self.hass, midnight_cb, dt_util.as_utc(next_midnight)
+        )
 
         # 2) Nasłuchiwanie zmian encji workday dla dziś i jutra (jeśli włączone)
         entities: list[str] = []
         if self._use_workday_sensor:
             if self._workday_today:
                 entities.append(self._workday_today)
-            if self._workday_tomorrow and self._workday_tomorrow != self._workday_today:
+            if (
+                self._workday_tomorrow
+                and self._workday_tomorrow != self._workday_today
+            ):
                 entities.append(self._workday_tomorrow)
 
         if entities:
-            async_track_state_change_event(
+            @callback
+            def _state_change(event) -> None:
+                self._update_state(dt_util.now())
+                self.async_write_ha_state()
+
+            self._workday_unsub = async_track_state_change_event(
                 self.hass,
                 entities,
-                lambda event: (self._update_state(), self.async_write_ha_state()),
+                _state_change,
             )
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._midnight_unsub:
+            self._midnight_unsub()
+            self._midnight_unsub = None
+        if self._workday_unsub:
+            self._workday_unsub()
+            self._workday_unsub = None
 
     def _get_schedule_code(self, day: date) -> int:
         """Zwraca kod zmiany dla danego dnia, z uwzględnieniem dni wolnych jeśli włączone."""
@@ -113,8 +135,13 @@ class WorkshiftDaySensor(SensorEntity):
         diff = (day - self._base_date).days
         if diff < 0:
             return 0
-        code = int(self._pattern[diff % len(self._pattern)])
-        
+        idx = diff % len(self._pattern)
+        try:
+            code = int(self._pattern[idx])
+        except (ValueError, IndexError):
+            _LOGGER.warning("Invalid schedule digit for day %s in pattern %s", day, self._pattern)
+            return 0
+
         # Sprawdź workday sensor tylko jeśli opcja jest włączona
         if self._use_workday_sensor:
             # Dobór encji workday na podstawie dnia
@@ -131,9 +158,23 @@ class WorkshiftDaySensor(SensorEntity):
                     return 0
         return code
 
-    def _update_state(self):
+    def _start_datetime(self, day: date, index: int):
+        if index < len(self.start_times):
+            start = self.start_times[index]
+        else:
+            _LOGGER.warning(
+                "Brak godziny rozpoczęcia dla zmiany %s, przyjmuję 00:00", index + 1
+            )
+            start = datetime.strptime("00:00", "%H:%M").time()
+        start_of_day = dt_util.start_of_local_day(day)
+        return start_of_day + timedelta(
+            hours=start.hour, minutes=start.minute, seconds=start.second
+        )
+
+    def _update_state(self, reference: datetime):
         """Ustawia wartość sensora i atrybuty startu/końca zmiany."""
-        target = date.today() + timedelta(days=self._offset)
+        reference = dt_util.as_local(reference)
+        target = reference.date() + timedelta(days=self._offset)
         code = self._get_schedule_code(target)
         if code == 0:
             self._attr_native_value = 0
@@ -141,11 +182,11 @@ class WorkshiftDaySensor(SensorEntity):
         else:
             self._attr_native_value = code
             idx = code - 1
-            start_dt = datetime.combine(target, self.start_times[idx])
+            start_dt = self._start_datetime(target, idx)
             end_dt = start_dt + timedelta(hours=self.shift_duration)
             self._attr_extra_state_attributes = {
-                "shift_start": start_dt.isoformat(),
-                "shift_end": end_dt.isoformat(),
+                "shift_start": dt_util.as_utc(start_dt).isoformat(),
+                "shift_end": dt_util.as_utc(end_dt).isoformat(),
             }
 
     @property

--- a/custom_components/workshift_sensor/translations/en.json
+++ b/custom_components/workshift_sensor/translations/en.json
@@ -1,108 +1,115 @@
 {
-    "title": "Workshift Sensor",
-    "config": {
-      "step": {
-        "user": {
-          "title": "General",
-          "description": "Provide a name and select the workday sensor.",
-          "data": {
-            "name": "Integration name",
-            "use_workday_sensor": "Respect weekends and holidays (use workday sensor)",
-            "workday_sensor": "Workday binary sensor",
-            "workday_sensor_tomorrow": "Workday sensor for tomorrow (optional)"
-          }
-        },
-        "shifts": {
-          "title": "Shifts",
-          "description": "Set the shift duration and number of shifts per day.",
-          "data": {
-            "shift_duration": "Shift duration (hours)",
-            "num_shifts": "Shifts per day"
-          }
-        },
-        "start_times": {
-          "title": "Start times",
-          "description": "Enter the start time for each shift (HH:MM).",
-          "data": {
-            "start_times_1": "Start time for shift 1",
-            "start_times_2": "Start time for shift 2",
-            "start_times_3": "Start time for shift 3",
-            "start_times_4": "Start time for shift 4",
-            "start_times_5": "Start time for shift 5",
-            "start_times_6": "Start time for shift 6",
-            "start_times_7": "Start time for shift 7",
-            "start_times_8": "Start time for shift 8",
-            "start_times_9": "Start time for shift 9"
-          }
-        },
-        "schedule": {
-          "title": "Schedule",
-          "description": "Define the shift schedule. Use 0 for off days, and 1–{max} for shift numbers.",
-          "data": {
-            "schedule_start": "Schedule start date",
-            "schedule": "Schedule pattern"
-          }
+  "title": "Workshift Sensor",
+  "config": {
+    "step": {
+      "user": {
+        "title": "General",
+        "description": "Provide a name and select the workday sensor.",
+        "data": {
+          "name": "Integration name",
+          "use_workday_sensor": "Respect weekends and holidays (use workday sensor)",
+          "workday_sensor": "Workday binary sensor",
+          "workday_sensor_tomorrow": "Workday sensor for tomorrow (optional)"
         }
       },
-      "error": {
-        "name_exists": "An integration with this name already exists.",
-        "invalid_num_shifts": "Number of shifts must be between 1 and 9.",
-        "invalid_time_format": "Time format must be HH:MM.",
-        "times_not_sorted": "Shift start times must be in increasing order.",
-        "invalid_date": "Date must be in format YYYY-MM-DD.",
-        "invalid_schedule": "Schedule must consist of digits from 0 to {max}."
+      "shifts": {
+        "title": "Shifts",
+        "description": "Set the shift duration and number of shifts per day.",
+        "data": {
+          "shift_duration": "Shift duration (hours)",
+          "num_shifts": "Shifts per day"
+        }
+      },
+      "start_times": {
+        "title": "Start times",
+        "description": "Enter the start time for each shift (HH:MM).",
+        "data": {
+          "start_times_1": "Start time for shift 1",
+          "start_times_2": "Start time for shift 2",
+          "start_times_3": "Start time for shift 3",
+          "start_times_4": "Start time for shift 4",
+          "start_times_5": "Start time for shift 5",
+          "start_times_6": "Start time for shift 6",
+          "start_times_7": "Start time for shift 7",
+          "start_times_8": "Start time for shift 8",
+          "start_times_9": "Start time for shift 9"
+        }
+      },
+      "schedule": {
+        "title": "Schedule",
+        "description": "Define the shift schedule. Use 0 for off days, and 1–{max} for shift numbers.",
+        "data": {
+          "schedule_start": "Schedule start date",
+          "schedule": "Schedule pattern"
+        }
       }
     },
-    "options": {
-      "step": {
-        "user": {
-          "title": "General",
-          "description": "Update name or workday sensor if needed.",
-          "data": {
-            "name": "Integration name",
-            "workday_sensor": "Workday binary sensor"
-          }
-        },
-        "shifts": {
-          "title": "Shifts",
-          "description": "Update shift duration or count if needed.",
-          "data": {
-            "shift_duration": "Shift duration (hours)",
-            "num_shifts": "Shifts per day"
-          }
-        },
-        "start_times": {
-          "title": "Start times",
-          "description": "Adjust shift start times if needed.",
-          "data": {
-            "start_times_1": "Start time for shift 1",
-            "start_times_2": "Start time for shift 2",
-            "start_times_3": "Start time for shift 3",
-            "start_times_4": "Start time for shift 4",
-            "start_times_5": "Start time for shift 5",
-            "start_times_6": "Start time for shift 6",
-            "start_times_7": "Start time for shift 7",
-            "start_times_8": "Start time for shift 8",
-            "start_times_9": "Start time for shift 9"
-          }
-        },
-        "schedule": {
-          "title": "Schedule",
-          "description": "Update the schedule pattern or start date.",
-          "data": {
-            "schedule_start": "Schedule start date",
-            "schedule": "Schedule pattern"
-          }
+    "error": {
+      "invalid_name": "Name cannot be empty.",
+      "name_exists": "An integration with this name already exists.",
+      "workday_required": "Select a workday sensor or disable the option to use it.",
+      "invalid_shift_duration": "Shift duration must be a positive number.",
+      "invalid_num_shifts": "Number of shifts must be between 1 and 9.",
+      "invalid_time_format": "Time format must be HH:MM.",
+      "times_not_sorted": "Shift start times must be in increasing order.",
+      "invalid_date": "Date must be in format YYYY-MM-DD.",
+      "invalid_schedule": "Schedule must consist of digits from 0 to {max}."
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "General",
+        "description": "Update the general settings if needed.",
+        "data": {
+          "name": "Integration name",
+          "use_workday_sensor": "Respect weekends and holidays (use workday sensor)",
+          "workday_sensor": "Workday binary sensor",
+          "workday_sensor_tomorrow": "Workday sensor for tomorrow (optional)"
         }
       },
-      "error": {
-        "name_exists": "An integration with this name already exists.",
-        "invalid_num_shifts": "Number of shifts must be between 1 and 9.",
-        "invalid_time_format": "Time format must be HH:MM.",
-        "times_not_sorted": "Shift start times must be in increasing order.",
-        "invalid_date": "Date must be in format YYYY-MM-DD.",
-        "invalid_schedule": "Schedule must consist of digits from 0 to {max}."
+      "shifts": {
+        "title": "Shifts",
+        "description": "Update shift duration or count if needed.",
+        "data": {
+          "shift_duration": "Shift duration (hours)",
+          "num_shifts": "Shifts per day"
+        }
+      },
+      "start_times": {
+        "title": "Start times",
+        "description": "Adjust shift start times if needed.",
+        "data": {
+          "start_times_1": "Start time for shift 1",
+          "start_times_2": "Start time for shift 2",
+          "start_times_3": "Start time for shift 3",
+          "start_times_4": "Start time for shift 4",
+          "start_times_5": "Start time for shift 5",
+          "start_times_6": "Start time for shift 6",
+          "start_times_7": "Start time for shift 7",
+          "start_times_8": "Start time for shift 8",
+          "start_times_9": "Start time for shift 9"
+        }
+      },
+      "schedule": {
+        "title": "Schedule",
+        "description": "Update the schedule pattern or start date.",
+        "data": {
+          "schedule_start": "Schedule start date",
+          "schedule": "Schedule pattern"
+        }
       }
+    },
+    "error": {
+      "invalid_name": "Name cannot be empty.",
+      "name_exists": "An integration with this name already exists.",
+      "workday_required": "Select a workday sensor or disable the option to use it.",
+      "invalid_shift_duration": "Shift duration must be a positive number.",
+      "invalid_num_shifts": "Number of shifts must be between 1 and 9.",
+      "invalid_time_format": "Time format must be HH:MM.",
+      "times_not_sorted": "Shift start times must be in increasing order.",
+      "invalid_date": "Date must be in format YYYY-MM-DD.",
+      "invalid_schedule": "Schedule must consist of digits from 0 to {max}."
     }
   }
-  
+}

--- a/custom_components/workshift_sensor/translations/pl.json
+++ b/custom_components/workshift_sensor/translations/pl.json
@@ -1,108 +1,115 @@
 {
-    "title": "Harmonogram Zmian",
-    "config": {
-      "step": {
-        "user": {
-          "title": "Ogólne",
-          "description": "Podaj nazwę integracji i wybierz czujnik dnia roboczego.",
-          "data": {
-            "name": "Nazwa integracji",
-            "use_workday_sensor": "Przestrzegaj weekendów i świąt (używaj czujnika dnia roboczego)",
-            "workday_sensor": "Czujnik dnia roboczego",
-            "workday_sensor_tomorrow": "Czujnik dnia roboczego na jutro (opcjonalny)"
-          }
-        },
-        "shifts": {
-          "title": "Zmiany",
-          "description": "Ustaw czas trwania zmiany i liczbę zmian na dobę.",
-          "data": {
-            "shift_duration": "Czas trwania zmiany (godziny)",
-            "num_shifts": "Liczba zmian na dobę"
-          }
-        },
-        "start_times": {
-          "title": "Godziny rozpoczęcia",
-          "description": "Wprowadź godziny rozpoczęcia każdej zmiany (HH:MM).",
-          "data": {
-            "start_times_1": "Godzina startu zmiany 1",
-            "start_times_2": "Godzina startu zmiany 2",
-            "start_times_3": "Godzina startu zmiany 3",
-            "start_times_4": "Godzina startu zmiany 4",
-            "start_times_5": "Godzina startu zmiany 5",
-            "start_times_6": "Godzina startu zmiany 6",
-            "start_times_7": "Godzina startu zmiany 7",
-            "start_times_8": "Godzina startu zmiany 8",
-            "start_times_9": "Godzina startu zmiany 9"
-          }
-        },
-        "schedule": {
-          "title": "Harmonogram",
-          "description": "Zdefiniuj grafik zmian. Użyj 0 dla dni wolnych i 1–{max} dla numerów zmian.",
-          "data": {
-            "schedule_start": "Data początkowa grafiku",
-            "schedule": "Grafik (ciąg cyfr)"
-          }
+  "title": "Harmonogram Zmian",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ogólne",
+        "description": "Podaj nazwę integracji i wybierz czujnik dnia roboczego.",
+        "data": {
+          "name": "Nazwa integracji",
+          "use_workday_sensor": "Uwzględniaj weekendy i święta (użyj czujnika dnia roboczego)",
+          "workday_sensor": "Czujnik dnia roboczego",
+          "workday_sensor_tomorrow": "Czujnik dnia roboczego na jutro (opcjonalny)"
         }
       },
-      "error": {
-        "name_exists": "Integracja o podanej nazwie już istnieje.",
-        "invalid_num_shifts": "Liczba zmian musi zawierać się między 1 a 9.",
-        "invalid_time_format": "Czas musi być w formacie HH:MM.",
-        "times_not_sorted": "Godziny zmian muszą być w kolejności rosnącej.",
-        "invalid_date": "Data musi mieć format RRRR-MM-DD.",
-        "invalid_schedule": "Grafik musi składać się z cyfr od 0 do {max}."
+      "shifts": {
+        "title": "Zmiany",
+        "description": "Ustaw czas trwania zmiany i liczbę zmian na dobę.",
+        "data": {
+          "shift_duration": "Czas trwania zmiany (godziny)",
+          "num_shifts": "Liczba zmian na dobę"
+        }
+      },
+      "start_times": {
+        "title": "Godziny rozpoczęcia",
+        "description": "Wprowadź godziny rozpoczęcia każdej zmiany (HH:MM).",
+        "data": {
+          "start_times_1": "Godzina startu zmiany 1",
+          "start_times_2": "Godzina startu zmiany 2",
+          "start_times_3": "Godzina startu zmiany 3",
+          "start_times_4": "Godzina startu zmiany 4",
+          "start_times_5": "Godzina startu zmiany 5",
+          "start_times_6": "Godzina startu zmiany 6",
+          "start_times_7": "Godzina startu zmiany 7",
+          "start_times_8": "Godzina startu zmiany 8",
+          "start_times_9": "Godzina startu zmiany 9"
+        }
+      },
+      "schedule": {
+        "title": "Harmonogram",
+        "description": "Zdefiniuj grafik zmian. Użyj 0 dla dni wolnych i 1–{max} dla numerów zmian.",
+        "data": {
+          "schedule_start": "Data początkowa grafiku",
+          "schedule": "Grafik (ciąg cyfr)"
+        }
       }
     },
-    "options": {
-      "step": {
-        "user": {
-          "title": "Ogólne",
-          "description": "Zmień nazwę lub czujnik dnia roboczego, jeśli potrzeba.",
-          "data": {
-            "name": "Nazwa integracji",
-            "workday_sensor": "Czujnik dnia roboczego"
-          }
-        },
-        "shifts": {
-          "title": "Zmiany",
-          "description": "Zaktualizuj czas trwania zmiany lub liczbę zmian.",
-          "data": {
-            "shift_duration": "Czas trwania zmiany (godziny)",
-            "num_shifts": "Liczba zmian na dobę"
-          }
-        },
-        "start_times": {
-          "title": "Godziny rozpoczęcia",
-          "description": "Dostosuj godziny rozpoczęcia każdej zmiany.",
-          "data": {
-            "start_times_1": "Godzina startu zmiany 1",
-            "start_times_2": "Godzina startu zmiany 2",
-            "start_times_3": "Godzina startu zmiany 3",
-            "start_times_4": "Godzina startu zmiany 4",
-            "start_times_5": "Godzina startu zmiany 5",
-            "start_times_6": "Godzina startu zmiany 6",
-            "start_times_7": "Godzina startu zmiany 7",
-            "start_times_8": "Godzina startu zmiany 8",
-            "start_times_9": "Godzina startu zmiany 9"
-          }
-        },
-        "schedule": {
-          "title": "Harmonogram",
-          "description": "Zaktualizuj ciąg grafiku lub datę początkową.",
-          "data": {
-            "schedule_start": "Data początkowa grafiku",
-            "schedule": "Grafik (ciąg cyfr)"
-          }
+    "error": {
+      "invalid_name": "Nazwa nie może być pusta.",
+      "name_exists": "Integracja o podanej nazwie już istnieje.",
+      "workday_required": "Wybierz czujnik dnia roboczego lub wyłącz tę opcję.",
+      "invalid_shift_duration": "Czas trwania zmiany musi być dodatni.",
+      "invalid_num_shifts": "Liczba zmian musi zawierać się między 1 a 9.",
+      "invalid_time_format": "Czas musi być w formacie HH:MM.",
+      "times_not_sorted": "Godziny rozpoczęcia muszą być w kolejności rosnącej.",
+      "invalid_date": "Data musi mieć format RRRR-MM-DD.",
+      "invalid_schedule": "Grafik musi składać się z cyfr od 0 do {max}."
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Ogólne",
+        "description": "Zaktualizuj ustawienia ogólne, jeśli to konieczne.",
+        "data": {
+          "name": "Nazwa integracji",
+          "use_workday_sensor": "Uwzględniaj weekendy i święta (użyj czujnika dnia roboczego)",
+          "workday_sensor": "Czujnik dnia roboczego",
+          "workday_sensor_tomorrow": "Czujnik dnia roboczego na jutro (opcjonalny)"
         }
       },
-      "error": {
-        "name_exists": "Integracja o podanej nazwie już istnieje.",
-        "invalid_num_shifts": "Liczba zmian musi zawierać się między 1 a 9.",
-        "invalid_time_format": "Czas musi być w formacie HH:MM.",
-        "times_not_sorted": "Godziny zmian muszą być w kolejności rosnącej.",
-        "invalid_date": "Data musi mieć format RRRR-MM-DD.",
-        "invalid_schedule": "Grafik musi składać się z cyfr od 0 do {max}."
+      "shifts": {
+        "title": "Zmiany",
+        "description": "Zaktualizuj czas trwania zmiany lub liczbę zmian.",
+        "data": {
+          "shift_duration": "Czas trwania zmiany (godziny)",
+          "num_shifts": "Liczba zmian na dobę"
+        }
+      },
+      "start_times": {
+        "title": "Godziny rozpoczęcia",
+        "description": "Dostosuj godziny rozpoczęcia każdej zmiany.",
+        "data": {
+          "start_times_1": "Godzina startu zmiany 1",
+          "start_times_2": "Godzina startu zmiany 2",
+          "start_times_3": "Godzina startu zmiany 3",
+          "start_times_4": "Godzina startu zmiany 4",
+          "start_times_5": "Godzina startu zmiany 5",
+          "start_times_6": "Godzina startu zmiany 6",
+          "start_times_7": "Godzina startu zmiany 7",
+          "start_times_8": "Godzina startu zmiany 8",
+          "start_times_9": "Godzina startu zmiany 9"
+        }
+      },
+      "schedule": {
+        "title": "Harmonogram",
+        "description": "Zaktualizuj ciąg grafiku lub datę początkową.",
+        "data": {
+          "schedule_start": "Data początkowa grafiku",
+          "schedule": "Grafik (ciąg cyfr)"
+        }
       }
+    },
+    "error": {
+      "invalid_name": "Nazwa nie może być pusta.",
+      "name_exists": "Integracja o podanej nazwie już istnieje.",
+      "workday_required": "Wybierz czujnik dnia roboczego lub wyłącz tę opcję.",
+      "invalid_shift_duration": "Czas trwania zmiany musi być dodatni.",
+      "invalid_num_shifts": "Liczba zmian musi zawierać się między 1 a 9.",
+      "invalid_time_format": "Czas musi być w formacie HH:MM.",
+      "times_not_sorted": "Godziny rozpoczęcia muszą być w kolejności rosnącej.",
+      "invalid_date": "Data musi mieć format RRRR-MM-DD.",
+      "invalid_schedule": "Grafik musi składać się z cyfr od 0 do {max}."
     }
   }
-  
+}


### PR DESCRIPTION
## Summary
- add an options flow so existing entries can be reconfigured from the UI
- reload entities when options change and merge options with stored data
- harden shift scheduling logic by using Home Assistant date utilities and validating configuration
- update translations with new validation messages and option labels

## Testing
- python -m compileall custom_components/workshift_sensor

------
https://chatgpt.com/codex/tasks/task_e_68d926aff158832ebf59976fd1bf4592