### PR TITLE
Add Workshift Sensor custom integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0
+
+- Initial public release of the Workshift Sensor integration.
+- Added four-step configuration and options flow with PL/EN translations.
+- Provided today/tomorrow shift sensors and an on-shift binary sensor with event-driven updates.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Workshift Sensor
+
+Workshift Sensor is a custom Home Assistant integration that helps track rotating production shifts according to a flexible, cyclic timetable. It provides a four-step configuration wizard and exposes sensors that describe the current and upcoming shifts, making it easy to automate workflows around staff availability.
+
+## Workshift Sensor — niestandardowa integracja HA do zarządzania grafikiem zmian
+
+Integracja działa całkowicie po stronie Home Assistanta, nie wymaga dodatkowych usług ani połączenia zewnętrznego. Każdy wpis konfiguracyjny tworzy osobne urządzenie wraz z trzema encjami:
+
+- `sensor.<prefix>_today_shift` – numer zmiany dla bieżącego dnia wraz z metadanymi (czas rozpoczęcia i zakończenia, opis, informacja o dniu roboczym).
+- `sensor.<prefix>_tomorrow_shift` – prognoza na kolejny dzień.
+- `binary_sensor.<prefix>_on_shift` – informacja czy w danej chwili trwa zmiana (uwzględnia zmiany przechodzące przez północ).
+
+## Schemat działania – konfiguracja przez kreator 4-etapowy
+
+Integracja korzysta z konfiguracyjnego kreatora UI Home Assistanta. Kolejne kroki obejmują:
+
+1. **Ustawienia ogólne** – nazwa wpisu oraz opcjonalne wykorzystanie czujnika dnia roboczego (osobno dla dziś i jutra).
+2. **Parametry zmian** – czas trwania pojedynczej zmiany oraz liczba zmian na dobę.
+3. **Godziny rozpoczęcia zmian** – dynamicznie generowane pola odpowiadające liczbie zmian.
+4. **Data startu i harmonogram** – wzorzec cyklicznych zmian zapętlany względem zadanej daty początkowej.
+
+Wszystkie kroki udostępniają tłumaczenia PL/EN oraz walidację danych w locie. Opcje można później zmienić w dedykowanym options flow.
+
+## Logika harmonogramu – obiekty `WorkshiftConfigData` i `WorkshiftSchedule`
+
+- **`WorkshiftConfigData`** przechowuje parametry wpisu konfiguracyjnego (czas zmiany, liczba zmian, godziny startów, wykorzystanie czujników dnia roboczego oraz wzorzec harmonogramu).
+- **`WorkshiftSchedule`** odpowiada za obliczenia na podstawie daty startowej oraz zapętlonego ciągu cyfr harmonogramu. Dla dowolnej daty zwraca odpowiednią zmianę (albo dzień wolny) oraz dokładne znaczniki czasu rozpoczęcia i zakończenia zmiany.
+
+Silnik aktualizacji działa w trybie asynchronicznym – integracja planuje kolejne odświeżenie zawsze na granicy zmiany (start, koniec, północ), zapewniając aktualne stany encji bez zbędnego odpytywania.
+
+## Udostępniane encje
+
+Każdy wpis integracji dodaje następujące encje:
+
+| Encja | Opis |
+| ----- | ---- |
+| `sensor.<prefix>_today_shift` | Numer i szczegóły bieżącej zmiany (czas startu, koniec, opis, status dnia roboczego). |
+| `sensor.<prefix>_tomorrow_shift` | Informacje o zmianie przewidzianej na jutro. |
+| `binary_sensor.<prefix>_on_shift` | Stan włączony, gdy aktualnie trwa zmiana (również gdy rozpoczęła się poprzedniego dnia). |
+
+Wszystkie encje mają stabilne identyfikatory `unique_id` oraz są powiązane z urządzeniem reprezentującym daną konfigurację.
+
+## Założenia
+
+- Harmonogram zapętla się względem daty startowej, a cyfra `0` oznacza dzień wolny.
+- Dane wejściowe przechodzą sanityzację – format godzin `HH:MM`, rosnąca kolejność startów, weryfikacja długości zmian oraz zgodności cyfr harmonogramu z liczbą zmian.
+- Integracja opcjonalnie korzysta z czujników dnia roboczego Home Assistanta (`binary_sensor.workday_sensor`). Można wskazać oddzielne encje dla dziś i jutra, a brak dedykowanego czujnika jutra skutkuje użyciem harmonogramu / prognozy dzisiejszego sensora.
+- Aktualizacje są planowane tylko w punktach granicznych (start/koniec zmiany, północ), co minimalizuje obciążenie systemu.
+
+## Instalacja przez HACS
+
+1. Dodaj repozytorium jako **Custom Repository** w HACS (typ: Integration).
+2. Zainstaluj integrację „Workshift Sensor”.
+3. Po restarcie Home Assistanta przejdź do **Ustawienia → Urządzenia i usługi → Dodaj integrację**, wyszukaj „Workshift Sensor” i uruchom kreator konfiguracji.
+
+## CHANGELOG
+
+Zobacz plik [CHANGELOG.md](CHANGELOG.md) dla listy zmian.
+
+## Licencja
+
+Projekt udostępniany jest na licencji MIT – szczegóły znajdują się w pliku [LICENSE](LICENSE).

--- a/custom_components/workshift_sensor/__init__.py
+++ b/custom_components/workshift_sensor/__init__.py
@@ -1,0 +1,397 @@
+"""Workshift Sensor integration setup."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from typing import Any, Callable, Dict, List, Optional
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr, dt_util
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import slugify
+
+from .const import (
+    CONF_ENTRY_NAME,
+    CONF_SCHEDULE_START_DATE,
+    CONF_SCHEDULE_STRING,
+    CONF_SHIFT_HOURS,
+    CONF_SHIFT_STARTS,
+    CONF_SHIFTS_PER_DAY,
+    CONF_USE_WORKDAY_SENSOR,
+    CONF_WORKDAY_ENTITY_TODAY,
+    CONF_WORKDAY_ENTITY_TOMORROW,
+    DEVICE_MANUFACTURER,
+    DOMAIN,
+    PLATFORMS,
+    WorkshiftConfigData,
+    WorkshiftInfo,
+    WorkshiftSchedule,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class WorkshiftRuntimeData:
+    """Runtime data stored per config entry."""
+
+    config: WorkshiftConfigData
+    schedule: WorkshiftSchedule
+    listeners: List[Callable[[], None]]
+    cancel_callback: Optional[Callable[[], None]]
+
+    today_shift: Optional[WorkshiftInfo] = None
+    tomorrow_shift: Optional[WorkshiftInfo] = None
+    current_shift: Optional[WorkshiftInfo] = None
+    today_is_workday: bool = True
+    tomorrow_is_workday: bool = True
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Workshift Sensor integration (YAML not supported)."""
+
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Workshift Sensor from a config entry."""
+
+    try:
+        config_data = _config_entry_to_data(entry)
+    except ValueError as err:
+        raise ConfigEntryNotReady(str(err)) from err
+
+    runtime = WorkshiftRuntimeData(
+        config=config_data,
+        schedule=WorkshiftSchedule(config_data),
+        listeners=[],
+        cancel_callback=None,
+    )
+    hass.data[DOMAIN][entry.entry_id] = runtime
+
+    await _async_register_device(hass, entry, config_data)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    _async_start_scheduler(hass, entry, runtime)
+
+    entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        runtime: WorkshiftRuntimeData = hass.data[DOMAIN].pop(entry.entry_id)
+        if runtime.cancel_callback:
+            runtime.cancel_callback()
+    return unload_ok
+
+
+async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle entry updates by reloading."""
+
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def _async_register_device(
+    hass: HomeAssistant, entry: ConfigEntry, config: WorkshiftConfigData
+) -> None:
+    """Ensure a device is present for the entry."""
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        name=config.entry_name,
+        manufacturer=DEVICE_MANUFACTURER,
+    )
+
+
+def _config_entry_to_data(entry: ConfigEntry) -> WorkshiftConfigData:
+    """Create config data object from entry data and options."""
+
+    raw: Dict[str, Any] = {**entry.data, **entry.options}
+    try:
+        shift_hours = int(raw[CONF_SHIFT_HOURS])
+        shifts_per_day = int(raw[CONF_SHIFTS_PER_DAY])
+        shift_starts = _parse_shift_starts(raw[CONF_SHIFT_STARTS], shifts_per_day)
+        schedule_start_date = date.fromisoformat(raw[CONF_SCHEDULE_START_DATE])
+        schedule_string = str(raw[CONF_SCHEDULE_STRING])
+    except (KeyError, ValueError) as err:
+        raise ValueError("Invalid configuration data") from err
+
+    return WorkshiftConfigData(
+        entry_name=str(raw[CONF_ENTRY_NAME]),
+        use_workday_sensor=bool(raw.get(CONF_USE_WORKDAY_SENSOR, False)),
+        workday_entity_today=raw.get(CONF_WORKDAY_ENTITY_TODAY),
+        workday_entity_tomorrow=raw.get(CONF_WORKDAY_ENTITY_TOMORROW),
+        shift_hours=shift_hours,
+        shifts_per_day=shifts_per_day,
+        shift_starts=shift_starts,
+        schedule_start_date=schedule_start_date,
+        schedule_string=schedule_string,
+    )
+
+
+def _parse_shift_starts(starts: List[str], shifts_per_day: int) -> List[time]:
+    """Parse a list of HH:MM strings to time objects."""
+
+    from datetime import datetime as dt
+
+    if len(starts) != shifts_per_day:
+        raise ValueError("Invalid number of shift start times")
+
+    parsed: List[datetime.time] = []
+    last_minutes: Optional[int] = None
+    for start_str in starts:
+        try:
+            parsed_time = dt.strptime(start_str, "%H:%M").time()
+        except ValueError as err:
+            raise ValueError(f"Invalid time format: {start_str}") from err
+        minutes = parsed_time.hour * 60 + parsed_time.minute
+        if last_minutes is not None and minutes <= last_minutes:
+            raise ValueError("Shift start times must be in ascending order")
+        last_minutes = minutes
+        parsed.append(parsed_time)
+    return parsed
+
+
+def _async_start_scheduler(
+    hass: HomeAssistant, entry: ConfigEntry, runtime: WorkshiftRuntimeData
+) -> None:
+    """Calculate initial state and schedule updates."""
+
+    _async_update_state(hass, entry, runtime)
+
+
+@callback
+def _async_update_state(
+    hass: HomeAssistant,
+    entry: Optional[ConfigEntry],
+    runtime: WorkshiftRuntimeData,
+) -> None:
+    """Update runtime state and notify listeners."""
+
+    now = dt_util.now()
+    tz = hass.config.time_zone
+    if tz is None:
+        _LOGGER.warning("Timezone is not configured; defaulting to UTC")
+
+    runtime.today_shift = _resolve_shift_for_day(
+        hass, runtime.config, runtime.schedule, now.date(), is_tomorrow=False
+    )
+    runtime.tomorrow_shift = _resolve_shift_for_day(
+        hass,
+        runtime.config,
+        runtime.schedule,
+        (now + timedelta(days=1)).date(),
+        is_tomorrow=True,
+    )
+    runtime.today_is_workday = runtime.today_shift is not None
+    runtime.tomorrow_is_workday = runtime.tomorrow_shift is not None
+    runtime.current_shift = _resolve_current_shift(
+        hass, runtime.config, runtime.schedule, now
+    )
+
+    _LOGGER.debug(
+        "Entry %s updated: today=%s tomorrow=%s current=%s",
+        entry.entry_id if entry else runtime.config.entry_name,
+        runtime.today_shift,
+        runtime.tomorrow_shift,
+        runtime.current_shift,
+    )
+
+    for listener in list(runtime.listeners):
+        listener()
+
+    _schedule_next_update(hass, entry, runtime, now)
+
+
+def _resolve_shift_for_day(
+    hass: HomeAssistant,
+    config: WorkshiftConfigData,
+    schedule: WorkshiftSchedule,
+    target_date: date,
+    *,
+    is_tomorrow: bool = False,
+) -> Optional[WorkshiftInfo]:
+    """Resolve shift info for a given day considering workday sensors."""
+
+    is_workday = _is_workday_for_date(
+        hass, config, target_date, True, is_tomorrow=is_tomorrow
+    )
+    if not is_workday:
+        return None
+
+    shift_info = schedule.get_shift_info(target_date)
+    if shift_info is None:
+        return None
+
+    return _localize_shift_info(shift_info, target_date, config)
+
+
+def _resolve_current_shift(
+    hass: HomeAssistant,
+    config: WorkshiftConfigData,
+    schedule: WorkshiftSchedule,
+    now: datetime,
+) -> Optional[WorkshiftInfo]:
+    """Determine if a shift is active at the current time."""
+
+    today = now.date()
+    info_today = _resolve_shift_for_day(
+        hass, config, schedule, today, is_tomorrow=False
+    )
+    if info_today and info_today.start <= now < info_today.end:
+        return info_today
+
+    yesterday = today - timedelta(days=1)
+    info_yesterday = schedule.get_shift_info(yesterday)
+    if info_yesterday is None:
+        return None
+    info_yesterday = _localize_shift_info(info_yesterday, yesterday, config)
+    if info_yesterday.start <= now < info_yesterday.end:
+        if not config.use_workday_sensor:
+            return info_yesterday
+        # Verify yesterday was considered a workday if sensors apply
+        if _is_workday_for_date(
+            hass, config, yesterday, True, is_tomorrow=False
+        ):
+            return info_yesterday
+    return None
+
+
+def _localize_shift_info(
+    shift_info: WorkshiftInfo,
+    target_date: date,
+    config: WorkshiftConfigData,
+) -> WorkshiftInfo:
+    """Localize naive shift info datetimes."""
+
+    base = dt_util.start_of_local_day(datetime.combine(target_date, time.min))
+    start = base.replace(
+        hour=shift_info.start.hour,
+        minute=shift_info.start.minute,
+        second=0,
+        microsecond=0,
+    )
+    end = start + timedelta(hours=config.shift_hours)
+    return WorkshiftInfo(shift_index=shift_info.shift_index, start=start, end=end)
+
+
+def _is_workday_for_date(
+    hass: HomeAssistant,
+    config: WorkshiftConfigData,
+    target_date: date,
+    default: bool,
+    *,
+    is_tomorrow: bool,
+) -> bool:
+    """Evaluate workday sensor state for a given date."""
+
+    if not config.use_workday_sensor:
+        return True
+
+    entity_id = config.workday_entity_tomorrow if is_tomorrow else config.workday_entity_today
+    if entity_id:
+        state = hass.states.get(entity_id)
+        if state is None:
+            _LOGGER.warning("Workday sensor %s not found", entity_id)
+            return default
+        if state.state in ("on", "true", "1", True):
+            return True
+        if state.state in ("off", "false", "0", False):
+            return False
+        attr_key = "tomorrow" if is_tomorrow else "today"
+        forecast = state.attributes.get(attr_key)
+        if isinstance(forecast, bool):
+            return forecast
+        return default
+
+    # Fall back to today's sensor forecast if tomorrow specific sensor missing
+    if is_tomorrow and config.workday_entity_today:
+        state = hass.states.get(config.workday_entity_today)
+        if state:
+            for key in ("tomorrow", "next_day", "next_workday"):
+                forecast = state.attributes.get(key)
+                if isinstance(forecast, bool):
+                    return forecast
+    return True
+
+
+def _schedule_next_update(
+    hass: HomeAssistant,
+    entry: Optional[ConfigEntry],
+    runtime: WorkshiftRuntimeData,
+    now: datetime,
+) -> None:
+    """Schedule the next automatic update based on upcoming shift boundaries."""
+
+    times: List[datetime] = []
+    for info in (
+        runtime.today_shift,
+        runtime.tomorrow_shift,
+        runtime.current_shift,
+    ):
+        if info:
+            times.extend([info.start, info.end])
+
+    # Always schedule for the next midnight to refresh the schedule
+    next_midnight = dt_util.start_of_local_day(now + timedelta(days=1))
+    times.append(next_midnight)
+
+    next_time = min((t for t in times if t and t > now + timedelta(seconds=5)), default=None)
+
+    if runtime.cancel_callback:
+        runtime.cancel_callback()
+        runtime.cancel_callback = None
+
+    if next_time is None:
+        next_time = now + timedelta(minutes=5)
+
+    _LOGGER.debug("Scheduling next update at %s", next_time)
+
+    runtime.cancel_callback = async_track_point_in_time(
+        hass,
+        lambda _: _async_update_state(hass, entry, runtime),
+        next_time,
+    )
+
+
+class WorkshiftEntityMixin:
+    """Mixin shared by all workshift entities."""
+
+    def __init__(self, entry: ConfigEntry, runtime: WorkshiftRuntimeData, entity_type: str) -> None:
+        self._entry = entry
+        self._runtime = runtime
+        self._entity_type = entity_type
+        self._attr_has_entity_name = True
+        self._attr_should_poll = False
+        slug = slugify(runtime.config.entry_name)
+        self._attr_unique_id = f"{slug}-{entity_type}-{entry.entry_id[:8]}"
+
+    @property
+    def device_info(self) -> Dict[str, Any]:
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": self._runtime.config.entry_name,
+            "manufacturer": DEVICE_MANUFACTURER,
+        }
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self.async_write_ha_state not in self._runtime.listeners:
+            self._runtime.listeners.append(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        await super().async_will_remove_from_hass()
+        if self.async_write_ha_state in self._runtime.listeners:
+            self._runtime.listeners.remove(self.async_write_ha_state)

--- a/custom_components/workshift_sensor/binary_sensor.py
+++ b/custom_components/workshift_sensor/binary_sensor.py
@@ -1,0 +1,54 @@
+"""Binary sensor platform for Workshift Sensor."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import WorkshiftEntityMixin, WorkshiftRuntimeData
+from .const import BINARY_SENSOR_ON_SHIFT, DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Workshift binary sensors for a config entry."""
+
+    runtime: WorkshiftRuntimeData = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([WorkshiftOnShiftBinarySensor(entry, runtime)])
+
+
+class WorkshiftOnShiftBinarySensor(WorkshiftEntityMixin, BinarySensorEntity):
+    """Binary sensor indicating if a shift is currently active."""
+
+    _attr_device_class = "occupancy"
+
+    def __init__(self, entry: ConfigEntry, runtime: WorkshiftRuntimeData) -> None:
+        super().__init__(entry, runtime, BINARY_SENSOR_ON_SHIFT)
+        self._attr_translation_key = BINARY_SENSOR_ON_SHIFT
+
+    @property
+    def is_on(self) -> bool:
+        return self._runtime.current_shift is not None
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        info = self._runtime.current_shift
+        if not info:
+            return {
+                "shift_index": None,
+                "start_datetime": None,
+                "end_datetime": None,
+                "is_workday": self._runtime.today_is_workday,
+            }
+        return {
+            "shift_index": info.shift_index,
+            "start_datetime": info.start.isoformat(),
+            "end_datetime": info.end.isoformat(),
+            "is_workday": self._runtime.today_is_workday,
+        }

--- a/custom_components/workshift_sensor/config_flow.py
+++ b/custom_components/workshift_sensor/config_flow.py
@@ -1,0 +1,470 @@
+"""Config flow for Workshift Sensor integration."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.helpers import selector
+
+from .const import (
+    CONF_ENTRY_NAME,
+    CONF_SCHEDULE_START_DATE,
+    CONF_SCHEDULE_STRING,
+    CONF_SHIFT_HOURS,
+    CONF_SHIFT_STARTS,
+    CONF_SHIFTS_PER_DAY,
+    CONF_USE_WORKDAY_SENSOR,
+    CONF_WORKDAY_ENTITY_TODAY,
+    CONF_WORKDAY_ENTITY_TOMORROW,
+    DEFAULT_SHIFT_HOURS,
+    DEFAULT_SHIFTS_PER_DAY,
+    DEFAULT_SCHEDULE_STRING,
+    DOMAIN,
+)
+
+GENERAL_STEP_ID = "user"
+SHIFTS_STEP_ID = "shifts"
+SHIFT_TIMES_STEP_ID = "shift_times"
+SCHEDULE_STEP_ID = "schedule"
+
+SHIFT_START_KEY_TEMPLATE = "shift_start_{index}"
+DEFAULT_ENTRY_NAME = "Workshift"
+
+
+class WorkshiftFlowHandlerBase:
+    """Shared helpers for both config and options flows."""
+
+    def __init__(self) -> None:
+        self._data: Dict[str, Any] = {}
+        self._shift_keys: List[str] = []
+
+    def _merge_defaults(self, user_input: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+        combined: Dict[str, Any] = {**self._data}
+        if user_input:
+            combined.update(user_input)
+        return combined
+
+    def _general_schema(self, user_input: Optional[Mapping[str, Any]]) -> vol.Schema:
+        data = self._merge_defaults(user_input)
+        use_workday = bool(data.get(CONF_USE_WORKDAY_SENSOR, False))
+        schema_dict: Dict[Any, Any] = {
+            vol.Required(
+                CONF_ENTRY_NAME,
+                default=data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME),
+            ): selector.selector({"text": {"multiline": False}}),
+            vol.Required(
+                CONF_USE_WORKDAY_SENSOR,
+                default=use_workday,
+            ): selector.selector({"boolean": {}}),
+        }
+        if use_workday:
+            schema_dict.update(
+                {
+                    vol.Required(
+                        CONF_WORKDAY_ENTITY_TODAY,
+                        default=data.get(CONF_WORKDAY_ENTITY_TODAY)
+                        or "binary_sensor.workday_sensor",
+                    ): selector.selector(
+                        {"entity": {"domain": "binary_sensor"}}
+                    ),
+                    vol.Optional(
+                        CONF_WORKDAY_ENTITY_TOMORROW,
+                        default=data.get(CONF_WORKDAY_ENTITY_TOMORROW, "") or "",
+                    ): selector.selector(
+                        {"entity": {"domain": "binary_sensor"}}
+                    ),
+                }
+            )
+        return vol.Schema(schema_dict)
+
+    def _shifts_schema(self, user_input: Optional[Mapping[str, Any]]) -> vol.Schema:
+        data = self._merge_defaults(user_input)
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_SHIFT_HOURS,
+                    default=int(data.get(CONF_SHIFT_HOURS, DEFAULT_SHIFT_HOURS)),
+                ): selector.selector(
+                    {
+                        "number": {
+                            "min": 1,
+                            "max": 24,
+                            "mode": "box",
+                            "step": 1,
+                        }
+                    }
+                ),
+                vol.Required(
+                    CONF_SHIFTS_PER_DAY,
+                    default=int(data.get(CONF_SHIFTS_PER_DAY, DEFAULT_SHIFTS_PER_DAY)),
+                ): selector.selector(
+                    {
+                        "number": {
+                            "min": 1,
+                            "max": 9,
+                            "mode": "box",
+                            "step": 1,
+                        }
+                    }
+                ),
+            }
+        )
+
+    def _shift_times_schema(self, user_input: Optional[Mapping[str, Any]]) -> vol.Schema:
+        shifts_per_day = int(self._data[CONF_SHIFTS_PER_DAY])
+        defaults = self._default_shift_starts()
+        schema_dict: Dict[Any, Any] = {}
+        self._shift_keys = []
+        for index in range(shifts_per_day):
+            key = SHIFT_START_KEY_TEMPLATE.format(index=index)
+            self._shift_keys.append(key)
+            default_value = defaults[index]
+            if user_input and key in user_input:
+                default_value = user_input[key]
+            schema_dict[vol.Required(key, default=default_value)] = selector.selector(
+                {"time": {}}
+            )
+        return vol.Schema(schema_dict)
+
+    def _schedule_schema(self, user_input: Optional[Mapping[str, Any]]) -> vol.Schema:
+        data = self._merge_defaults(user_input)
+        start_default = data.get(CONF_SCHEDULE_START_DATE, self._default_schedule_start())
+        schedule_default = data.get(CONF_SCHEDULE_STRING, DEFAULT_SCHEDULE_STRING)
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_SCHEDULE_START_DATE,
+                    default=start_default,
+                ): selector.selector({"date": {}}),
+                vol.Required(
+                    CONF_SCHEDULE_STRING,
+                    default=schedule_default,
+                ): selector.selector({"text": {"multiline": False}}),
+            }
+        )
+
+    def _default_shift_starts(self) -> List[str]:
+        shifts_per_day = int(self._data.get(CONF_SHIFTS_PER_DAY, DEFAULT_SHIFTS_PER_DAY))
+        existing = self._data.get(CONF_SHIFT_STARTS)
+        if isinstance(existing, list) and len(existing) == shifts_per_day:
+            return [str(value) for value in existing]
+
+        base_time_str = "06:00"
+        if existing:
+            base_time_str = str(existing[0])
+
+        try:
+            base_time = datetime.strptime(base_time_str, "%H:%M")
+        except ValueError:
+            base_time = datetime.strptime("06:00", "%H:%M")
+
+        shift_hours = int(self._data.get(CONF_SHIFT_HOURS, DEFAULT_SHIFT_HOURS))
+        values: List[str] = []
+        for index in range(shifts_per_day):
+            current = base_time + timedelta(hours=shift_hours * index)
+            values.append(current.time().strftime("%H:%M"))
+        return values
+
+    def _default_schedule_start(self) -> str:
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+        return monday.isoformat()
+
+    def _clean_general(self, user_input: Mapping[str, Any]) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            CONF_ENTRY_NAME: str(user_input[CONF_ENTRY_NAME]).strip() or DEFAULT_ENTRY_NAME,
+            CONF_USE_WORKDAY_SENSOR: bool(user_input[CONF_USE_WORKDAY_SENSOR]),
+            CONF_WORKDAY_ENTITY_TODAY: None,
+            CONF_WORKDAY_ENTITY_TOMORROW: None,
+        }
+        if data[CONF_USE_WORKDAY_SENSOR]:
+            today_entity = user_input.get(CONF_WORKDAY_ENTITY_TODAY)
+            if today_entity:
+                data[CONF_WORKDAY_ENTITY_TODAY] = today_entity
+            tomorrow = user_input.get(CONF_WORKDAY_ENTITY_TOMORROW)
+            if tomorrow:
+                data[CONF_WORKDAY_ENTITY_TOMORROW] = tomorrow
+        return data
+
+    def _clean_shift_core(self, user_input: Mapping[str, Any]) -> Dict[str, Any]:
+        return {
+            CONF_SHIFT_HOURS: int(user_input[CONF_SHIFT_HOURS]),
+            CONF_SHIFTS_PER_DAY: int(user_input[CONF_SHIFTS_PER_DAY]),
+        }
+
+    def _clean_shift_times(self, user_input: Mapping[str, Any]) -> Dict[str, Any]:
+        start_values = [str(user_input[key]) for key in self._shift_keys]
+        validated = _validate_shift_starts(start_values)
+        return {CONF_SHIFT_STARTS: validated}
+
+    def _clean_schedule(self, user_input: Mapping[str, Any]) -> Dict[str, Any]:
+        start_date = str(user_input[CONF_SCHEDULE_START_DATE])
+        schedule = str(user_input[CONF_SCHEDULE_STRING]).strip().replace(" ", "")
+        return {
+            CONF_SCHEDULE_START_DATE: start_date,
+            CONF_SCHEDULE_STRING: schedule,
+        }
+
+    def _finalize(self) -> Dict[str, Any]:
+        result = dict(self._data)
+        if not result.get(CONF_USE_WORKDAY_SENSOR, False):
+            result.pop(CONF_WORKDAY_ENTITY_TODAY, None)
+            result.pop(CONF_WORKDAY_ENTITY_TOMORROW, None)
+        else:
+            if not result.get(CONF_WORKDAY_ENTITY_TOMORROW):
+                result.pop(CONF_WORKDAY_ENTITY_TOMORROW, None)
+        return result
+
+
+class WorkshiftConfigFlow(WorkshiftFlowHandlerBase, config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for the Workshift Sensor."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            cleaned = self._clean_general(user_input)
+            if cleaned[CONF_USE_WORKDAY_SENSOR] and not cleaned.get(CONF_WORKDAY_ENTITY_TODAY):
+                errors[CONF_WORKDAY_ENTITY_TODAY] = "workday_required"
+            else:
+                self._data.update(cleaned)
+                return await self.async_step_shifts()
+
+        self.context["title_placeholders"] = {
+            "entry_name": self._data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME)
+        }
+
+        return self.async_show_form(
+            step_id=GENERAL_STEP_ID,
+            data_schema=self._general_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_shifts(self, user_input: Optional[Dict[str, Any]] = None):
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            cleaned = self._clean_shift_core(user_input)
+            shift_hours = cleaned[CONF_SHIFT_HOURS]
+            shifts_per_day = cleaned[CONF_SHIFTS_PER_DAY]
+            if not 1 <= shift_hours <= 24:
+                errors[CONF_SHIFT_HOURS] = "invalid_shift_hours"
+            elif not 1 <= shifts_per_day <= 9:
+                errors[CONF_SHIFTS_PER_DAY] = "invalid_shifts_per_day"
+            else:
+                self._data.update(cleaned)
+                return await self.async_step_shift_times()
+
+        self.context["title_placeholders"] = {
+            "entry_name": self._data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME)
+        }
+
+        return self.async_show_form(
+            step_id=SHIFTS_STEP_ID,
+            data_schema=self._shifts_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_shift_times(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ):
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            try:
+                cleaned = self._clean_shift_times(user_input)
+            except ValueError as err:
+                errors["base"] = str(err)
+            else:
+                self._data.update(cleaned)
+                return await self.async_step_schedule()
+
+        self.context["title_placeholders"] = {
+            "entry_name": self._data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME)
+        }
+
+        return self.async_show_form(
+            step_id=SHIFT_TIMES_STEP_ID,
+            data_schema=self._shift_times_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_schedule(self, user_input: Optional[Dict[str, Any]] = None):
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            cleaned = self._clean_schedule(user_input)
+            try:
+                _validate_schedule(
+                    cleaned[CONF_SCHEDULE_START_DATE],
+                    cleaned[CONF_SCHEDULE_STRING],
+                    int(self._data[CONF_SHIFTS_PER_DAY]),
+                )
+            except ValueError as err:
+                errors["base"] = str(err)
+            else:
+                self._data.update(cleaned)
+                final_data = self._finalize()
+                title = final_data[CONF_ENTRY_NAME]
+                return self.async_create_entry(title=title, data=final_data)
+
+        self.context["title_placeholders"] = {
+            "entry_name": self._data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME)
+        }
+
+        return self.async_show_form(
+            step_id=SCHEDULE_STEP_ID,
+            data_schema=self._schedule_schema(user_input),
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        return WorkshiftOptionsFlow(config_entry)
+
+
+class WorkshiftOptionsFlow(WorkshiftFlowHandlerBase, config_entries.OptionsFlow):
+    """Options flow allowing to reconfigure the integration."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        super().__init__()
+        self._config_entry = config_entry
+        self._data.update({**config_entry.data, **config_entry.options})
+
+    async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None):
+        return await self.async_step_user(user_input)
+
+    async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            cleaned = self._clean_general(user_input)
+            if cleaned[CONF_USE_WORKDAY_SENSOR] and not cleaned.get(CONF_WORKDAY_ENTITY_TODAY):
+                errors[CONF_WORKDAY_ENTITY_TODAY] = "workday_required"
+            else:
+                self._data.update(cleaned)
+                return await self.async_step_shifts()
+
+        self.context["title_placeholders"] = {
+            "entry_name": self._data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME)
+        }
+
+        return self.async_show_form(
+            step_id=GENERAL_STEP_ID,
+            data_schema=self._general_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_shifts(self, user_input: Optional[Dict[str, Any]] = None):
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            cleaned = self._clean_shift_core(user_input)
+            shift_hours = cleaned[CONF_SHIFT_HOURS]
+            shifts_per_day = cleaned[CONF_SHIFTS_PER_DAY]
+            if not 1 <= shift_hours <= 24:
+                errors[CONF_SHIFT_HOURS] = "invalid_shift_hours"
+            elif not 1 <= shifts_per_day <= 9:
+                errors[CONF_SHIFTS_PER_DAY] = "invalid_shifts_per_day"
+            else:
+                self._data.update(cleaned)
+                return await self.async_step_shift_times()
+
+        self.context["title_placeholders"] = {
+            "entry_name": self._data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME)
+        }
+
+        return self.async_show_form(
+            step_id=SHIFTS_STEP_ID,
+            data_schema=self._shifts_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_shift_times(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ):
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            try:
+                cleaned = self._clean_shift_times(user_input)
+            except ValueError as err:
+                errors["base"] = str(err)
+            else:
+                self._data.update(cleaned)
+                return await self.async_step_schedule()
+
+        self.context["title_placeholders"] = {
+            "entry_name": self._data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME)
+        }
+
+        return self.async_show_form(
+            step_id=SHIFT_TIMES_STEP_ID,
+            data_schema=self._shift_times_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_schedule(self, user_input: Optional[Dict[str, Any]] = None):
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            cleaned = self._clean_schedule(user_input)
+            try:
+                _validate_schedule(
+                    cleaned[CONF_SCHEDULE_START_DATE],
+                    cleaned[CONF_SCHEDULE_STRING],
+                    int(self._data[CONF_SHIFTS_PER_DAY]),
+                )
+            except ValueError as err:
+                errors["base"] = str(err)
+            else:
+                self._data.update(cleaned)
+                final_data = self._finalize()
+                return self.async_create_entry(title="", data=final_data)
+
+        self.context["title_placeholders"] = {
+            "entry_name": self._data.get(CONF_ENTRY_NAME, DEFAULT_ENTRY_NAME)
+        }
+
+        return self.async_show_form(
+            step_id=SCHEDULE_STEP_ID,
+            data_schema=self._schedule_schema(user_input),
+            errors=errors,
+        )
+
+
+def _validate_shift_starts(values: List[str]) -> List[str]:
+    """Validate shift start times and return normalized list."""
+
+    last_minutes: Optional[int] = None
+    normalized: List[str] = []
+    for value in values:
+        try:
+            parsed = datetime.strptime(value, "%H:%M")
+        except ValueError as err:
+            raise ValueError("invalid_shift_start_format") from err
+        minutes = parsed.hour * 60 + parsed.minute
+        if last_minutes is not None and minutes <= last_minutes:
+            raise ValueError("invalid_shift_start_order")
+        last_minutes = minutes
+        normalized.append(parsed.time().strftime("%H:%M"))
+    return normalized
+
+
+def _validate_schedule(start_date: str, schedule: str, shifts_per_day: int) -> None:
+    """Validate schedule string and start date."""
+
+    try:
+        date.fromisoformat(start_date)
+    except ValueError as err:
+        raise ValueError("invalid_schedule_date") from err
+
+    if not schedule:
+        raise ValueError("invalid_schedule_pattern")
+    if not schedule.isdigit():
+        raise ValueError("invalid_schedule_pattern")
+    if any(int(ch) > shifts_per_day for ch in schedule):
+        raise ValueError("invalid_schedule_digit")

--- a/custom_components/workshift_sensor/const.py
+++ b/custom_components/workshift_sensor/const.py
@@ -1,0 +1,99 @@
+"""Constants for the Workshift Sensor integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from typing import List, Optional
+
+DOMAIN = "workshift_sensor"
+PLATFORMS = ["sensor", "binary_sensor"]
+
+CONF_ENTRY_NAME = "entry_name"
+CONF_USE_WORKDAY_SENSOR = "use_workday_sensor"
+CONF_WORKDAY_ENTITY_TODAY = "workday_entity_today"
+CONF_WORKDAY_ENTITY_TOMORROW = "workday_entity_tomorrow"
+CONF_SHIFT_HOURS = "shift_hours"
+CONF_SHIFTS_PER_DAY = "shifts_per_day"
+CONF_SHIFT_STARTS = "shift_starts"
+CONF_SCHEDULE_START_DATE = "schedule_start_date"
+CONF_SCHEDULE_STRING = "schedule_string"
+
+DEFAULT_SHIFT_HOURS = 8
+DEFAULT_SHIFTS_PER_DAY = 3
+DEFAULT_SCHEDULE_STRING = "333330022222001111100"
+
+SENSOR_TODAY = "today_shift"
+SENSOR_TOMORROW = "tomorrow_shift"
+BINARY_SENSOR_ON_SHIFT = "on_shift"
+
+DEVICE_MANUFACTURER = "Workshift Tools"
+
+
+@dataclass(slots=True)
+class WorkshiftConfigData:
+    """Container for validated Workshift configuration."""
+
+    entry_name: str
+    use_workday_sensor: bool
+    workday_entity_today: Optional[str]
+    workday_entity_tomorrow: Optional[str]
+    shift_hours: int
+    shifts_per_day: int
+    shift_starts: List[time]
+    schedule_start_date: date
+    schedule_string: str
+
+    @property
+    def workday_entities(self) -> List[str]:
+        """Return available workday sensor entity IDs."""
+
+        entities: List[str] = []
+        if self.workday_entity_today:
+            entities.append(self.workday_entity_today)
+        if self.workday_entity_tomorrow and (
+            self.workday_entity_tomorrow != self.workday_entity_today
+        ):
+            entities.append(self.workday_entity_tomorrow)
+        return entities
+
+
+@dataclass(slots=True)
+class WorkshiftInfo:
+    """Represents a resolved shift for a given day."""
+
+    shift_index: int
+    start: datetime
+    end: datetime
+
+
+class WorkshiftSchedule:
+    """Provides utilities for resolving shifts based on a cyclic schedule."""
+
+    def __init__(self, config: WorkshiftConfigData) -> None:
+        self._config = config
+
+    def _index_for_date(self, target_date: date) -> int:
+        offset = (target_date - self._config.schedule_start_date).days
+        length = len(self._config.schedule_string)
+        # Handle negative offsets by wrapping around.
+        return offset % length
+
+    def get_shift_code(self, target_date: date) -> int:
+        """Return the scheduled shift code for the given date."""
+
+        index = self._index_for_date(target_date)
+        return int(self._config.schedule_string[index])
+
+    def get_shift_info(self, target_date: date) -> Optional[WorkshiftInfo]:
+        """Return detailed shift info for the given date, if any."""
+
+        shift_code = self.get_shift_code(target_date)
+        if shift_code <= 0:
+            return None
+        if shift_code > self._config.shifts_per_day:
+            return None
+
+        start_time = self._config.shift_starts[shift_code - 1]
+        start_dt = datetime.combine(target_date, start_time)
+        end_dt = start_dt + timedelta(hours=self._config.shift_hours)
+        return WorkshiftInfo(shift_index=shift_code, start=start_dt, end=end_dt)

--- a/custom_components/workshift_sensor/manifest.json
+++ b/custom_components/workshift_sensor/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "workshift_sensor",
+  "name": "Workshift Sensor",
+  "version": "1.0.0",
+  "config_flow": true,
+  "documentation": "https://github.com/example/workshift_sensor",
+  "issue_tracker": "https://github.com/example/workshift_sensor/issues",
+  "codeowners": ["@example"],
+  "iot_class": "calculated",
+  "integration_type": "helper",
+  "requirements": []
+}

--- a/custom_components/workshift_sensor/sensor.py
+++ b/custom_components/workshift_sensor/sensor.py
@@ -1,0 +1,88 @@
+"""Sensor platform for Workshift Sensor integration."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import WorkshiftEntityMixin, WorkshiftRuntimeData
+from .const import DOMAIN, SENSOR_TODAY, SENSOR_TOMORROW, WorkshiftInfo
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Workshift sensors for a config entry."""
+
+    runtime: WorkshiftRuntimeData = hass.data[DOMAIN][entry.entry_id]
+    entities = [
+        WorkshiftSensor(entry, runtime, SENSOR_TODAY),
+        WorkshiftSensor(entry, runtime, SENSOR_TOMORROW),
+    ]
+    async_add_entities(entities)
+
+
+class WorkshiftSensor(WorkshiftEntityMixin, SensorEntity):
+    """Represents a Workshift numeric sensor."""
+
+    _attr_icon = "mdi:calendar-clock"
+
+    def __init__(self, entry: ConfigEntry, runtime: WorkshiftRuntimeData, sensor_type: str) -> None:
+        super().__init__(entry, runtime, sensor_type)
+        self._sensor_type = sensor_type
+        self._attr_translation_key = sensor_type
+
+    @property
+    def native_value(self) -> int:
+        info = self._get_shift_info()
+        if info is None:
+            return 0
+        return info.shift_index
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        info = self._get_shift_info()
+        is_workday = self._is_workday()
+        if info is None:
+            return {
+                "shift_index": None,
+                "start_datetime": None,
+                "end_datetime": None,
+                "start_time": None,
+                "end_time": None,
+                "description": None,
+                "is_workday": is_workday,
+            }
+        attrs = _build_attributes(info)
+        attrs["is_workday"] = is_workday
+        return attrs
+
+    def _get_shift_info(self) -> Optional[WorkshiftInfo]:
+        if self._sensor_type == SENSOR_TODAY:
+            return self._runtime.today_shift
+        if self._sensor_type == SENSOR_TOMORROW:
+            return self._runtime.tomorrow_shift
+        return None
+
+    def _is_workday(self) -> bool:
+        if self._sensor_type == SENSOR_TODAY:
+            return self._runtime.today_is_workday
+        if self._sensor_type == SENSOR_TOMORROW:
+            return self._runtime.tomorrow_is_workday
+        return False
+
+
+def _build_attributes(info: WorkshiftInfo) -> Dict[str, Any]:
+    return {
+        "shift_index": info.shift_index,
+        "start_datetime": info.start.isoformat(),
+        "end_datetime": info.end.isoformat(),
+        "start_time": info.start.strftime("%H:%M"),
+        "end_time": info.end.strftime("%H:%M"),
+        "description": f"Shift {info.shift_index}",
+    }

--- a/custom_components/workshift_sensor/translations/en.json
+++ b/custom_components/workshift_sensor/translations/en.json
@@ -1,0 +1,109 @@
+{
+  "title": "Workshift Sensor",
+  "config": {
+    "flow_title": "{entry_name}",
+    "step": {
+      "user": {
+        "title": "General settings",
+        "description": "Provide the integration name and decide if a workday sensor should be used. You can pick separate entities for today and tomorrow for improved accuracy.",
+        "data": {
+          "entry_name": "Entry name",
+          "use_workday_sensor": "Use workday sensor",
+          "workday_entity_today": "Workday sensor for today",
+          "workday_entity_tomorrow": "Workday sensor for tomorrow (optional)"
+        }
+      },
+      "shifts": {
+        "title": "Shift parameters",
+        "description": "Define the duration of a single shift and the number of shifts per day.",
+        "data": {
+          "shift_hours": "Shift length (hours)",
+          "shifts_per_day": "Shifts per day"
+        }
+      },
+      "shift_times": {
+        "title": "Shift start times",
+        "description": "Enter the start time for every shift. The number of fields follows the value from the previous screen.",
+        "data": {}
+      },
+      "schedule": {
+        "title": "Schedule pattern",
+        "description": "Provide the schedule start date and the recurring pattern. The sequence loops from the start date.",
+        "data": {
+          "schedule_start_date": "Schedule start date",
+          "schedule_string": "Schedule pattern"
+        }
+      }
+    },
+    "error": {
+      "workday_required": "Select a workday sensor for today.",
+      "invalid_shift_hours": "Shift length must be between 1 and 24 hours.",
+      "invalid_shifts_per_day": "The number of shifts per day must be between 1 and 9.",
+      "invalid_shift_start_format": "Use the HH:MM format for all shift start times.",
+      "invalid_shift_start_order": "Shift start times must be in ascending order without overlaps.",
+      "invalid_schedule_date": "Provide a valid start date in YYYY-MM-DD format.",
+      "invalid_schedule_pattern": "The schedule pattern must contain only digits and cannot be empty.",
+      "invalid_schedule_digit": "Schedule digits cannot exceed the number of shifts per day."
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "General settings",
+        "description": "Provide the integration name and decide if a workday sensor should be used. You can pick separate entities for today and tomorrow for improved accuracy.",
+        "data": {
+          "entry_name": "Entry name",
+          "use_workday_sensor": "Use workday sensor",
+          "workday_entity_today": "Workday sensor for today",
+          "workday_entity_tomorrow": "Workday sensor for tomorrow (optional)"
+        }
+      },
+      "shifts": {
+        "title": "Shift parameters",
+        "description": "Define the duration of a single shift and the number of shifts per day.",
+        "data": {
+          "shift_hours": "Shift length (hours)",
+          "shifts_per_day": "Shifts per day"
+        }
+      },
+      "shift_times": {
+        "title": "Shift start times",
+        "description": "Enter the start time for every shift. The number of fields follows the value from the previous screen.",
+        "data": {}
+      },
+      "schedule": {
+        "title": "Schedule pattern",
+        "description": "Provide the schedule start date and the recurring pattern. The sequence loops from the start date.",
+        "data": {
+          "schedule_start_date": "Schedule start date",
+          "schedule_string": "Schedule pattern"
+        }
+      }
+    },
+    "error": {
+      "workday_required": "Select a workday sensor for today.",
+      "invalid_shift_hours": "Shift length must be between 1 and 24 hours.",
+      "invalid_shifts_per_day": "The number of shifts per day must be between 1 and 9.",
+      "invalid_shift_start_format": "Use the HH:MM format for all shift start times.",
+      "invalid_shift_start_order": "Shift start times must be in ascending order without overlaps.",
+      "invalid_schedule_date": "Provide a valid start date in YYYY-MM-DD format.",
+      "invalid_schedule_pattern": "The schedule pattern must contain only digits and cannot be empty.",
+      "invalid_schedule_digit": "Schedule digits cannot exceed the number of shifts per day."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "today_shift": {
+        "name": "Today's shift"
+      },
+      "tomorrow_shift": {
+        "name": "Tomorrow's shift"
+      }
+    },
+    "binary_sensor": {
+      "on_shift": {
+        "name": "On shift now"
+      }
+    }
+  }
+}

--- a/custom_components/workshift_sensor/translations/pl.json
+++ b/custom_components/workshift_sensor/translations/pl.json
@@ -1,0 +1,109 @@
+{
+  "title": "Workshift Sensor",
+  "config": {
+    "flow_title": "{entry_name}",
+    "step": {
+      "user": {
+        "title": "Ustawienia ogólne",
+        "description": "Podaj nazwę integracji i zdecyduj, czy chcesz uwzględniać czujnik dnia roboczego. Możesz wskazać osobne encje dla dziś i jutra, aby zwiększyć dokładność.",
+        "data": {
+          "entry_name": "Nazwa integracji",
+          "use_workday_sensor": "Uwzględniaj czujnik dnia roboczego",
+          "workday_entity_today": "Czujnik dnia roboczego na dziś",
+          "workday_entity_tomorrow": "Czujnik dnia roboczego na jutro (opcjonalnie)"
+        }
+      },
+      "shifts": {
+        "title": "Parametry zmian",
+        "description": "Zdefiniuj czas trwania jednej zmiany i liczbę zmian w ciągu doby.",
+        "data": {
+          "shift_hours": "Czas trwania zmiany (w godzinach)",
+          "shifts_per_day": "Liczba zmian na dobę"
+        }
+      },
+      "shift_times": {
+        "title": "Godziny rozpoczęcia zmian",
+        "description": "Podaj godziny rozpoczęcia wszystkich zmian. Liczba pól odpowiada liczbie zmian z poprzedniego ekranu.",
+        "data": {}
+      },
+      "schedule": {
+        "title": "Data startu i harmonogram",
+        "description": "Podaj datę rozpoczęcia harmonogramu i wzorzec pracy. Harmonogram zapętla się względem daty startowej.",
+        "data": {
+          "schedule_start_date": "Data rozpoczęcia harmonogramu",
+          "schedule_string": "Wzorzec zmian"
+        }
+      }
+    },
+    "error": {
+      "workday_required": "Wybierz czujnik dnia roboczego dla dzisiejszej zmiany.",
+      "invalid_shift_hours": "Czas zmiany musi mieścić się w zakresie 1-24 godziny.",
+      "invalid_shifts_per_day": "Liczba zmian na dobę musi mieścić się w zakresie 1-9.",
+      "invalid_shift_start_format": "Użyj formatu HH:MM dla wszystkich godzin rozpoczęcia.",
+      "invalid_shift_start_order": "Godziny rozpoczęcia muszą być w porządku rosnącym i nie mogą się nakładać.",
+      "invalid_schedule_date": "Podaj prawidłową datę początkową w formacie RRRR-MM-DD.",
+      "invalid_schedule_pattern": "Wzorzec harmonogramu musi składać się wyłącznie z cyfr i nie może być pusty.",
+      "invalid_schedule_digit": "Cyfry wzorca nie mogą przekraczać liczby zmian w ciągu doby."
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Ustawienia ogólne",
+        "description": "Podaj nazwę integracji i zdecyduj, czy chcesz uwzględniać czujnik dnia roboczego. Możesz wskazać osobne encje dla dziś i jutra, aby zwiększyć dokładność.",
+        "data": {
+          "entry_name": "Nazwa integracji",
+          "use_workday_sensor": "Uwzględniaj czujnik dnia roboczego",
+          "workday_entity_today": "Czujnik dnia roboczego na dziś",
+          "workday_entity_tomorrow": "Czujnik dnia roboczego na jutro (opcjonalnie)"
+        }
+      },
+      "shifts": {
+        "title": "Parametry zmian",
+        "description": "Zdefiniuj czas trwania jednej zmiany i liczbę zmian w ciągu doby.",
+        "data": {
+          "shift_hours": "Czas trwania zmiany (w godzinach)",
+          "shifts_per_day": "Liczba zmian na dobę"
+        }
+      },
+      "shift_times": {
+        "title": "Godziny rozpoczęcia zmian",
+        "description": "Podaj godziny rozpoczęcia wszystkich zmian. Liczba pól odpowiada liczbie zmian z poprzedniego ekranu.",
+        "data": {}
+      },
+      "schedule": {
+        "title": "Data startu i harmonogram",
+        "description": "Podaj datę rozpoczęcia harmonogramu i wzorzec pracy. Harmonogram zapętla się względem daty startowej.",
+        "data": {
+          "schedule_start_date": "Data rozpoczęcia harmonogramu",
+          "schedule_string": "Wzorzec zmian"
+        }
+      }
+    },
+    "error": {
+      "workday_required": "Wybierz czujnik dnia roboczego dla dzisiejszej zmiany.",
+      "invalid_shift_hours": "Czas zmiany musi mieścić się w zakresie 1-24 godziny.",
+      "invalid_shifts_per_day": "Liczba zmian na dobę musi mieścić się w zakresie 1-9.",
+      "invalid_shift_start_format": "Użyj formatu HH:MM dla wszystkich godzin rozpoczęcia.",
+      "invalid_shift_start_order": "Godziny rozpoczęcia muszą być w porządku rosnącym i nie mogą się nakładać.",
+      "invalid_schedule_date": "Podaj prawidłową datę początkową w formacie RRRR-MM-DD.",
+      "invalid_schedule_pattern": "Wzorzec harmonogramu musi składać się wyłącznie z cyfr i nie może być pusty.",
+      "invalid_schedule_digit": "Cyfry wzorca nie mogą przekraczać liczby zmian w ciągu doby."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "today_shift": {
+        "name": "Dzisiejsza zmiana"
+      },
+      "tomorrow_shift": {
+        "name": "Jutrzejsza zmiana"
+      }
+    },
+    "binary_sensor": {
+      "on_shift": {
+        "name": "Trwa zmiana"
+      }
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "Workshift Sensor",
+  "render_readme": true,
+  "domains": ["sensor", "binary_sensor"],
+  "country": ["PL", "EN"],
+  "homeassistant": "2023.0.0"
+}


### PR DESCRIPTION
## Summary
- add the Workshift Sensor custom integration with event-driven scheduling, sensors, and binary sensor entities
- implement full four-step config and options flows with validations and multilingual translations
- document installation and usage while preparing HACS metadata and changelog

## Testing
- python -m compileall custom_components/workshift_sensor

------
https://chatgpt.com/codex/tasks/task_e_68da309a7824832e95503ec149b466e0