### PR TITLE
Update integration type to hub

### DIFF
--- a/custom_components/workshift_sensor/manifest.json
+++ b/custom_components/workshift_sensor/manifest.json
@@ -7,6 +7,6 @@
   "issue_tracker": "https://github.com/example/workshift_sensor/issues",
   "codeowners": ["@example"],
   "iot_class": "calculated",
-  "integration_type": "helper",
+  "integration_type": "hub",
   "requirements": []
 }


### PR DESCRIPTION
## Summary
- change the integration type from helper to hub so the integration is no longer categorized as a helper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da37c9dbd8832e88246e97465030d3